### PR TITLE
Modularize frontend page styles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,3 @@
-/* ====================
-   Layout Geral
-   ==================== */
 .page-header {
   display: flex;
   justify-content: space-between;
@@ -81,9 +78,6 @@
   flex: 1;
 }
 
-/* ====================
-   Sidebar
-   ==================== */
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -130,9 +124,12 @@
   font-weight: 600;
 }
 
-/* ====================
-   Branding
-   ==================== */
+.layout__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
 .layout__brand-image {
   width: 64px;
   height: 64px;
@@ -158,205 +155,6 @@
   color: rgba(224, 231, 255, 0.75);
 }
 
-/* ====================
-   Auth Pages
-   ==================== */
-.auth {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-}
-
-.auth__content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2.5rem;
-  width: min(520px, 100%);
-  margin: 0 auto;
-  position: relative;
-  z-index: 1;
-}
-
-.auth__header {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.auth__kicker {
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.auth__header h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  font-weight: 700;
-  color: #e2f2ff;
-}
-
-.auth__subtitle {
-  color: var(--color-muted);
-}
-
-/* ====================
-   Auth Card (base)
-   ==================== */
-.auth-card {
-  width: min(420px, 100%);
-  background: linear-gradient(180deg, rgba(7, 15, 25, 0.95) 0%, rgba(6, 24, 34, 0.92) 100%);
-  border-radius: 1.5rem;
-  padding: 2.5rem;
-  box-shadow: 0 30px 70px rgba(1, 17, 30, 0.65);
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  display: flex;
-  flex-direction: column;
-  gap: 1.6rem;
-  color: #f8fafc;
-  position: relative;
-}
-
-.auth-card__logo {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 0.65rem;
-}
-
-.auth-card__logo img {
-  max-width: 140px;
-  width: 100%;
-  height: auto;
-  object-fit: contain;
-}
-
-.auth-card__header h2 {
-  font-size: 1.5rem;
-  margin-bottom: 0.25rem;
-}
-
-.auth-card__header p {
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.auth-card__footer {
-  text-align: center;
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.75);
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-/* ====================
-   Auth Card Variantes
-   ==================== */
-.auth-card--neon::before {
-  content: '';
-  position: absolute;
-  inset: -16px;
-  border-radius: 1.8rem;
-  background: linear-gradient(160deg, rgba(34, 197, 94, 0.6), rgba(59, 130, 246, 0.6));
-  filter: blur(30px);
-  opacity: 0.6;
-  z-index: -1;
-}
-
-/* ====================
-   Inputs e Fields
-   ==================== */
-.field--icon .field__input-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.field--icon input {
-  background: transparent;
-  border: none;
-  color: #e2e8f0;
-  flex: 1;
-  padding: 0.85rem 1rem 0.85rem 3rem;
-}
-
-.field--icon input::placeholder {
-  color: rgba(148, 163, 184, 0.6);
-}
-
-.field__icon {
-  position: absolute;
-  left: 1rem;
-  width: 1.1rem;
-  height: 1.1rem;
-  color: rgba(148, 163, 184, 0.9);
-}
-
-/* ====================
-   Botões e Links
-   ==================== */
-.button {
-  border: none;
-  border-radius: 0.75rem;
-  padding: 0.65rem 1.25rem;
-  font-size: 0.95rem;
-  font-weight: 500;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.button--primary {
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
-  color: #fff;
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
-}
-
-.button--primary:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
-
-.button--neon {
-  width: 100%;
-  border: none;
-  border-radius: 0.9rem;
-  background: linear-gradient(120deg, #34d399 0%, #059669 100%);
-  color: #052012;
-  font-weight: 600;
-  padding: 0.95rem 1rem;
-  box-shadow: 0 24px 40px rgba(4, 120, 87, 0.35);
-}
-
-.button--neon:hover:not(:disabled) {
-  transform: translateY(-2px);
-}
-
-.link-button {
-  border: none;
-  background: none;
-  color: rgba(125, 211, 252, 0.9);
-  font-weight: 500;
-  cursor: pointer;
-  padding: 0;
-}
-
-.link-button--muted {
-  color: rgba(148, 163, 184, 0.85);
-}
-
-/* ====================
-   Responsividade
-   ==================== */
 @media (max-width: 1024px) {
   .layout {
     grid-template-columns: 1fr;
@@ -366,6 +164,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    padding: 1.5rem;
   }
 
   .sidebar {
@@ -384,21 +183,16 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
+    padding: 1.25rem 1.5rem;
   }
 
-  .form--inline {
-    flex-direction: column;
-    align-items: stretch;
+  .layout__main {
+    padding: 1.5rem;
   }
 }
 
 @media (max-width: 640px) {
-  .auth-card {
-    padding: 2rem 1.75rem;
-    border-radius: 1.25rem;
-  }
-
-  .auth__header h1 {
-    font-size: 2rem;
+  .layout__main {
+    padding: 1.25rem;
   }
 }

--- a/frontend/src/components/charts/EntradasSaidasChart.jsx
+++ b/frontend/src/components/charts/EntradasSaidasChart.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import './charts.css'
 import {
   ResponsiveContainer,
   LineChart,

--- a/frontend/src/components/charts/charts.css
+++ b/frontend/src/components/charts/charts.css
@@ -1,0 +1,26 @@
+.chart-tooltip {
+  background: rgba(15, 23, 42, 0.92);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  color: #e2e8f0;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
+}
+
+.chart-tooltip__label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.45rem;
+}
+
+.chart-tooltip ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.chart-tooltip li {
+  font-size: 0.85rem;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import { AuthProvider } from './context/AuthContext.jsx'
 import './index.css'
+import './styles/base.css'
 import './App.css'
 
 const root = document.getElementById('root')

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -1,0 +1,81 @@
+.dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.metric {
+  background: var(--color-card);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.12);
+}
+
+.metric__label {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.metric__value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.metric__description {
+  color: var(--color-muted);
+}
+
+.metric--compact .metric__value {
+  font-size: 1.8rem;
+}
+
+.metric--compact .metric__description {
+  font-size: 0.9rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.dashboard-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.card--chart {
+  gap: 1.5rem;
+}
+
+.card--chart > *:last-child {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.card--chart-lg {
+  min-height: 420px;
+}
+
+.card--chart-lg > *:last-child {
+  align-items: center;
+}
+
+.card--wide {
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .dashboard-grid--two {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-metrics {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -4,6 +4,7 @@ import { api } from '../services/api.js'
 import { EntradasSaidasChart, ValorMovimentadoChart } from '../components/charts/EntradasSaidasChart.jsx'
 import { EstoquePorMaterialChart, MateriaisMaisUsadosChart } from '../components/charts/EstoqueCharts.jsx'
 import { EstoquePorCategoriaChart } from '../components/charts/EstoqueCategoriaChart.jsx'
+import './DashboardPage.css'
 
 const initialFilters = {
   ano: new Date().getFullYear(),
@@ -235,8 +236,6 @@ export function DashboardPage() {
     () => montarRanking(data?.materiaisMaisMovimentados ?? [], termoNormalizado),
     [data, termoNormalizado],
   )
-
-  const alertasQtd = data?.estoqueAtual?.alertas?.length ?? 0
 
   return (
     <div className="stack">

--- a/frontend/src/pages/EstoquePage.css
+++ b/frontend/src/pages/EstoquePage.css
@@ -1,0 +1,101 @@
+.alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.alert-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+}
+
+.alert-list__material {
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.alert-list__deficit {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary-dark);
+}
+
+.badge--alert {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.list__item {
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.list__item--alert {
+  border-color: rgba(202, 138, 4, 0.6);
+  box-shadow: 0 0 0 2px rgba(202, 138, 4, 0.2);
+}
+
+.list__item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.list__item-header h3 {
+  font-size: 1.1rem;
+}
+
+.list__item-header p {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.list__item-meta {
+  display: flex;
+  gap: 0.5rem 1.5rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.list__item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}

--- a/frontend/src/pages/EstoquePage.jsx
+++ b/frontend/src/pages/EstoquePage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { PageHeader } from '../components/PageHeader.jsx'
 import { api } from '../services/api.js'
+import './EstoquePage.css'
 
 const initialFilters = {
   ano: '',

--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -1,0 +1,172 @@
+.auth {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  background: linear-gradient(160deg, rgba(8, 16, 24, 0.95) 0%, rgba(7, 21, 28, 0.92) 100%);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 40px 80px rgba(2, 12, 20, 0.55);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: #f8fafc;
+  position: relative;
+}
+
+.auth-card--neon::before {
+  content: '';
+  position: absolute;
+  inset: -16px;
+  border-radius: 1.8rem;
+  background: linear-gradient(160deg, rgba(34, 197, 94, 0.6), rgba(59, 130, 246, 0.6));
+  filter: blur(30px);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.auth-card__logo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.65rem;
+}
+
+.auth-card__logo img {
+  max-width: 140px;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.auth-card__titles {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auth-card__kicker {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.auth-card__titles h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #e2f2ff;
+}
+
+.auth-card__subtitle {
+  color: rgba(191, 219, 254, 0.82);
+  font-size: 0.9rem;
+}
+
+.field--panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.field--panel span {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.field__panel {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.95rem;
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 219, 255, 0.35);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field__panel svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: rgba(13, 148, 136, 0.9);
+}
+
+.field__panel input {
+  border: none;
+  background: transparent;
+  flex: 1;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.field__panel input::placeholder {
+  color: rgba(100, 116, 139, 0.65);
+}
+
+.field__panel:focus-within {
+  border-color: rgba(34, 197, 94, 0.75);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
+}
+
+.auth-card__options {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.checkbox input {
+  accent-color: #22d3ee;
+}
+
+.button--neon {
+  width: 100%;
+  border: none;
+  border-radius: 0.9rem;
+  background: linear-gradient(120deg, #34d399 0%, #059669 100%);
+  color: #052012;
+  font-weight: 600;
+  padding: 0.95rem 1rem;
+  box-shadow: 0 24px 40px rgba(4, 120, 87, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button--neon:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.auth-card__footer {
+  text-align: center;
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.72);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 2rem 1.75rem;
+    border-radius: 1.25rem;
+  }
+
+  .auth-card__titles h1 {
+    font-size: 2rem;
+  }
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext.jsx'
+import './LoginPage.css'
 
 const logoSrc = '/logo_epicontrol.png'
 

--- a/frontend/src/pages/MateriaisPage.css
+++ b/frontend/src/pages/MateriaisPage.css
@@ -1,0 +1,20 @@
+.data-table__history {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.history-list li {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.85rem;
+  color: rgba(71, 85, 105, 0.9);
+  flex-wrap: wrap;
+}

--- a/frontend/src/pages/MateriaisPage.jsx
+++ b/frontend/src/pages/MateriaisPage.jsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import { PageHeader } from '../components/PageHeader.jsx'
 import { api } from '../services/api.js'
 import { useAuth } from '../context/AuthContext.jsx'
+import './MateriaisPage.css'
 
 const initialForm = {
   nome: '',

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -4,12 +4,6 @@
   gap: 1.5rem;
 }
 
-.grid {\n  display: grid;\n  gap: 1.5rem;\n  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));\n}
-
-.grid--metrics {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
 .card {
   background: var(--color-card);
   border: 1px solid rgba(15, 23, 42, 0.05);
@@ -26,56 +20,7 @@
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-}
-
-.card__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.card__link {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 1rem;
-  border-radius: 1rem;
-  background: rgba(37, 99, 235, 0.05);
-  border: 1px solid rgba(37, 99, 235, 0.1);
-}
-
-.card__link:hover {
-  border-color: var(--color-primary);
-}
-
-.card__link-title {
-  font-weight: 600;
-}
-
-.card__link-description {
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
-.card__list-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 0.9rem;
-  background: rgba(148, 163, 184, 0.08);
-}
-
-.badge {
-  background: rgba(37, 99, 235, 0.1);
-  color: var(--color-primary-dark);
-  padding: 0.2rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  flex-wrap: wrap;
 }
 
 .form {
@@ -129,7 +74,7 @@
   border-radius: 0.9rem;
   border: 1px solid var(--color-border);
   background: rgba(255, 255, 255, 0.95);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .field input:focus,
@@ -137,6 +82,58 @@
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.button--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--color-primary-dark);
+  border: 1px solid var(--color-border);
+  box-shadow: none;
+}
+
+.button--ghost:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary-dark);
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: rgba(59, 130, 246, 0.9);
+  font-weight: 500;
+  padding: 0;
+  cursor: pointer;
+}
+
+.link-button--muted {
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .feedback {
@@ -149,793 +146,6 @@
   font-weight: 500;
 }
 
-.alert {
-  background: rgba(202, 138, 4, 0.1);
-  border: 1px solid rgba(202, 138, 4, 0.3);
-  padding: 1rem;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.list__item {
-  background: rgba(248, 250, 252, 0.95);
-  border-radius: 1rem;
-  padding: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.list__item--alert {
-  border-color: rgba(202, 138, 4, 0.6);
-  box-shadow: 0 0 0 2px rgba(202, 138, 4, 0.2);
-}
-
-.list__item-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.list__item-header h3 {
-  font-size: 1.1rem;
-}
-
-.list__item-header p {
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
-.list__item-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1.5rem;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
-.list__item-body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  color: var(--color-muted);
-  font-size: 0.9rem;
-}
-
-.list__item-footer {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.list__history {
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
-  padding-top: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.list__history-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  font-size: 0.85rem;
-  color: var(--color-muted);
-  flex-wrap: wrap;
-}
-
-.table__cell--mono {
-  font-family: 'Fira Code', SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-}
-
-.metric {
-  background: var(--color-card);
-  border-radius: 1.25rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(37, 99, 235, 0.15);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.12);
-}
-
-.metric__label {
-  color: var(--color-muted);
-  font-size: 0.95rem;
-}
-
-.metric__value {
-  font-size: 2rem;
-  font-weight: 700;
-}
-
-.metric__description {
-  color: var(--color-muted);
-}
-
-.auth {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-}
-
-.auth__card {
-  width: min(420px, 100%);
-  background: var(--color-card);
-  padding: 2.5rem;
-  border-radius: 1.5rem;
-  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.15);
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.auth__subtitle {
-  color: var(--color-muted);
-}
-
-@media (max-width: 1024px) {
-  .layout {
-    grid-template-columns: 1fr;
-  }
-
-  .layout__sidebar {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .sidebar__section {
-    min-width: 180px;
-  }
-}.sidebar__section {
-    min-width: 180px;
-  }
-}
-
-@media (max-width: 768px) {
-  .layout__topbar {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-
-  .form--inline {
-    flex-direction: column;
-    align-items: stretch;
-  }
-}
-
-
-
-
-\n.auth__hint {
-  font-size: 0.85rem;
-  color: var(--color-muted);
-}
-
-.auth__hint code {
-  font-family: "Fira Code", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  background: rgba(15, 23, 42, 0.08);
-  padding: 0.1rem 0.4rem;
-  border-radius: 0.5rem;
-}
-
-.auth__content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2.5rem;
-  width: 100%;
-}
-
-.auth__header {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.auth__kicker {
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.auth__header h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  font-weight: 700;
-  color: #e2f2ff;
-}
-
-.auth-card {
-  width: min(440px, 100%);
-  background: rgba(7, 16, 24, 0.82);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(59, 130, 246, 0.25);
-  border-radius: 1.75rem;
-  padding: 2.5rem;
-  box-shadow: 0 35px 70px rgba(8, 47, 73, 0.45);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.auth-card__header h2 {
-  font-size: 1.5rem;
-  margin-bottom: 0.25rem;
-}
-
-.auth-card__header p {
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.field--icon .field__input-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.field--icon input {
-  background: transparent;
-  border: none;
-  color: #e2e8f0;
-  flex: 1;
-  padding: 0.85rem 1rem 0.85rem 3rem;
-}
-
-.field--icon input::placeholder {
-  color: rgba(148, 163, 184, 0.6);
-}
-
-.field__icon {
-  position: absolute;
-  left: 1rem;
-  width: 1.1rem;
-  height: 1.1rem;
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.field--icon .field__input-wrapper:focus-within {
-  border-color: rgba(74, 222, 128, 0.65);
-  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.15);
-}
-
-.auth-card__actions {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.link-button {
-  border: none;
-  background: none;
-  color: rgba(59, 130, 246, 0.9);
-  font-size: 0.9rem;
-  padding: 0;
-}
-
-.link-button--muted {
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.button--highlight {
-  width: 100%;
-  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
-  color: #06281f;
-  font-weight: 600;
-  font-size: 1rem;
-  padding: 0.9rem 1.2rem;
-  box-shadow: 0 18px 40px rgba(22, 163, 74, 0.35);
-}
-
-.button--highlight:hover:not(:disabled) {
-  transform: translateY(-2px);
-}
-
-.auth-card__footer {
-  text-align: center;
-  font-size: 0.9rem;
-  color: rgba(148, 163, 184, 0.85);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.auth-card__footer p:first-child {
-  font-style: italic;
-}
-
-@media (max-width: 640px) {
-  .auth-card {
-    padding: 2rem;
-    border-radius: 1.25rem;
-  }
-
-  .auth__header h1 {
-    font-size: 2rem;
-  }
-}
-
-.auth__content {
-  position: relative;
-  z-index: 1;
-}
-
-.auth-card {
-  color: #f8fafc;
-}
-
-.link-button {
-  cursor: pointer;
-}
-
-.auth__content {
-  width: min(520px, 100%);
-  margin: 0 auto;
-}
-
-.auth-card {
-  width: 100%;
-}
-
-.auth-card {
-  width: min(420px, 100%);
-  background: linear-gradient(160deg, rgba(8, 16, 24, 0.95) 0%, rgba(7, 21, 28, 0.92) 100%);
-  border-radius: 1.5rem;
-  padding: 2.5rem;
-  box-shadow: 0 40px 80px rgba(2, 12, 20, 0.55);
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  color: #f8fafc;
-  position: relative;
-}
-
-.auth-card--neon::before {
-  content: '';
-  position: absolute;
-  inset: -12px;
-  border-radius: 1.75rem;
-  background: linear-gradient(160deg, rgba(34, 197, 94, 0.45), rgba(59, 130, 246, 0.45));
-  filter: blur(28px);
-  opacity: 0.55;
-  z-index: -1;
-}
-
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.auth-card__kicker {
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.35em;
-  color: rgba(148, 200, 255, 0.85);
-}
-
-.auth-card__titles h1 {
-  font-size: 1.65rem;
-  font-weight: 600;
-}
-
-.auth-card__subtitle {
-  font-size: 0.9rem;
-  color: rgba(191, 219, 254, 0.85);
-}
-
-.field--panel {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.field--panel span {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: rgba(226, 232, 240, 0.8);
-}
-
-.field__panel {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: 0.95rem;
-  border: 1px solid rgba(148, 219, 255, 0.35);
-  background: rgba(248, 250, 252, 0.9);
-  padding: 0.65rem 0.9rem;
-}
-
-.field__panel svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  color: rgba(15, 118, 110, 0.9);
-}
-
-.field__panel input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  color: #0f172a;
-  font-size: 0.95rem;
-}
-
-.field__panel input::placeholder {
-  color: rgba(100, 116, 139, 0.65);
-}
-
-.field__panel:focus-within {
-  border-color: rgba(34, 197, 94, 0.7);
-  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.25);
-}
-
-.auth-card__options {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.85rem;
-  color: rgba(209, 213, 219, 0.85);
-}
-
-.checkbox {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.checkbox input {
-  accent-color: #2dd4bf;
-}
-
-.button--neon {
-  width: 100%;
-  border: none;
-  border-radius: 0.9rem;
-  background: linear-gradient(120deg, #34d399 0%, #059669 100%);
-  color: #04241c;
-  font-weight: 600;
-  padding: 0.95rem 1rem;
-  font-size: 1rem;
-  box-shadow: 0 28px 40px rgba(5, 150, 105, 0.35);
-  transition: transform 0.15s ease;
-}
-
-.button--neon:hover:not(:disabled) {
-  transform: translateY(-2px);
-}
-
-.link-button {
-  border: none;
-  background: none;
-  color: rgba(125, 211, 252, 0.9);
-  font-weight: 500;
-  padding: 0;
-}
-
-.link-button--muted {
-  color: rgba(148, 163, 184, 0.85);
-}
-
-.auth-card__footer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  text-align: center;
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.75);
-}
-
-@media (max-width: 640px) {
-  .auth-card {
-    padding: 2rem 1.75rem;
-    border-radius: 1.25rem;
-  }
-}
-
-.auth {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-}
-
-.auth-card {
-  width: min(420px, 100%);
-  background: linear-gradient(180deg, rgba(7, 15, 25, 0.95) 0%, rgba(6, 24, 34, 0.92) 100%);
-  border-radius: 1.5rem;
-  padding: 2.5rem;
-  box-shadow: 0 30px 70px rgba(1, 17, 30, 0.65);
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  display: flex;
-  flex-direction: column;
-  gap: 1.6rem;
-  color: #f8fafc;
-  position: relative;
-}
-
-.auth-card--neon::before {
-  content: '';
-  position: absolute;
-  inset: -16px;
-  border-radius: 1.8rem;
-  background: linear-gradient(160deg, rgba(34, 197, 94, 0.6), rgba(59, 130, 246, 0.6));
-  filter: blur(30px);
-  opacity: 0.6;
-  z-index: -1;
-}
-
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.auth-card__kicker {
-  text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.35em;
-  color: rgba(148, 200, 255, 0.85);
-}
-
-.auth-card__titles h1 {
-  font-size: 1.6rem;
-  font-weight: 600;
-}
-
-.auth-card__subtitle {
-  font-size: 0.85rem;
-  color: rgba(191, 219, 254, 0.82);
-}
-
-.field--panel {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.field--panel span {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: rgba(226, 232, 240, 0.8);
-}
-
-.field__panel {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.95rem;
-  background: rgba(248, 250, 252, 0.95);
-  border: 1px solid rgba(148, 219, 255, 0.35);
-}
-
-.field__panel svg {
-  width: 1.05rem;
-  height: 1.05rem;
-  color: rgba(13, 148, 136, 0.9);
-}
-
-.field__panel input {
-  border: none;
-  background: transparent;
-  flex: 1;
-  color: #0f172a;
-}
-
-.field__panel input::placeholder {
-  color: rgba(100, 116, 139, 0.65);
-}
-
-.field__panel:focus-within {
-  border-color: rgba(34, 197, 94, 0.75);
-  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
-}
-
-.auth-card__options {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.85);
-}
-
-.checkbox {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.checkbox input {
-  accent-color: #22d3ee;
-}
-
-.button--neon {
-  width: 100%;
-  border: none;
-  border-radius: 0.9rem;
-  background: linear-gradient(120deg, #34d399 0%, #059669 100%);
-  color: #052012;
-  font-weight: 600;
-  padding: 0.95rem 1rem;
-  box-shadow: 0 24px 40px rgba(4, 120, 87, 0.35);
-}
-
-.link-button {
-  border: none;
-  background: none;
-  color: rgba(148, 197, 255, 0.9);
-  cursor: pointer;
-}
-
-.link-button--muted {
-  color: rgba(203, 213, 225, 0.75);
-}
-
-.auth-card__footer {
-  text-align: center;
-  font-size: 0.82rem;
-  color: rgba(226, 232, 240, 0.72);
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-@media (max-width: 640px) {
-  .auth-card {
-    padding: 2rem 1.75rem;
-    border-radius: 1.2rem;
-  }
-}
-
-.chart-tooltip {
-  background: rgba(15, 23, 42, 0.92);
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  color: #e2e8f0;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
-}
-
-.chart-tooltip__label {
-  display: block;
-  font-weight: 600;
-  margin-bottom: 0.45rem;
-}
-
-.chart-tooltip ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.chart-tooltip li {
-  font-size: 0.85rem;
-}
-.dashboard-metrics {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.metric--compact {
-  padding: 1.2rem;
-  gap: 0.35rem;
-}
-
-.metric--compact .metric__value {
-  font-size: 1.65rem;
-}
-
-.metric--compact .metric__description {
-  font-size: 0.85rem;
-}
-
-.dashboard-grid {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.dashboard-grid--two {
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-}
-
-.card--chart {
-  min-height: 320px;
-  display: flex;
-  flex-direction: column;
-}
-
-.card--chart > *:last-child {
-  flex: 1;
-}
-
-.card--wide {
-  min-height: 320px;
-}
-
-@media (max-width: 768px) {
-  .dashboard-grid--two {
-    grid-template-columns: 1fr;
-  }
-}
-.card--chart {
-  overflow: hidden;
-}
-.alert-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.alert-list__item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.9rem 1.1rem;
-  border-radius: 1rem;
-  background: rgba(248, 113, 113, 0.08);
-  border: 1px solid rgba(248, 113, 113, 0.25);
-}
-
-.alert-list__item span {
-  font-size: 0.9rem;
-  color: rgba(100, 116, 139, 0.95);
-}
-
-.alert-list__material {
-  font-size: 0.82rem;
-  color: rgba(71, 85, 105, 0.85);
-}
-
-.alert-list__deficit {
-  color: #b91c1c;
-  font-weight: 600;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.2rem 0.65rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.badge--alert {
-  background: rgba(248, 113, 113, 0.2);
-  color: #b91c1c;
-  border: 1px solid rgba(248, 113, 113, 0.4);
-}
 .table-wrapper {
   width: 100%;
   overflow-x: auto;
@@ -974,44 +184,10 @@
   color: rgba(100, 116, 139, 0.85);
 }
 
-.data-table__history {
-  background: rgba(148, 163, 184, 0.08);
+@media (max-width: 768px) {
+  .form--inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
-
-.history-list {
-  list-style: none;
-  margin: 0;
-  padding: 0.5rem 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.history-list li {
-  display: flex;
-  gap: 1.25rem;
-  font-size: 0.85rem;
-  color: rgba(71, 85, 105, 0.9);
-  flex-wrap: wrap;
-}
-.dashboard-grid--two {
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-}
-
-.card--chart-lg {
-  min-height: 420px;
-}
-
-.card--chart-lg > *:last-child {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  margin-bottom: 0.65rem;
-}
-
-  max-width: 140px;
-  width: 100%;
-  height: auto;
-  object-fit: contain;
-}\n/* Login logo */\n.auth-card__logo {\n  display: flex;\n  justify-content: center;\n  margin-bottom: 0.65rem;\n}\n\n.auth-card__logo img {\n  max-width: 140px;\n  width: 100%;\n  height: auto;\n  object-fit: contain;\n}\n\n
 


### PR DESCRIPTION
## Summary
- reorganize the CSS imports so App.css holds only the layout shell while base.css centralizes shared utilities
- add dedicated stylesheets for the login, dashboard, estoque and materiais pages together with chart tooltip styling
- ensure the new base stylesheet is loaded once from main.jsx so every page can use the shared form, button and table patterns

## Testing
- npm run lint *(fails: pre-existing issues in AuthContext.jsx, api.js and vite.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d321b9a71883229872274582f631c2