### PR TITLE
Remove duplicated :root declarations from page styles

### DIFF
--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -1,13 +1,3 @@
-:root {
-  --color-primary: #16a34a;       /* verde segurança */
-  --color-primary-dark: #065f46;  /* verde institucional */
-  --color-accent: #2563eb;        /* azul ações */
-  --color-warning: #facc15;       /* amarelo alerta */
-  --color-danger: #dc2626;        /* vermelho crítico */
-  --color-muted: #6b7280;         /* cinza secundário */
-  --color-card: #ffffff;          /* fundo padrão dos cards */
-}
-
 /* Highlights principais */
 .dashboard-highlights {
   display: grid;

--- a/frontend/src/styles/EstoquePage.css
+++ b/frontend/src/styles/EstoquePage.css
@@ -1,13 +1,3 @@
-:root {
-  --color-primary: #16a34a;       /* verde segurança */
-  --color-primary-dark: #065f46;  /* verde institucional */
-  --color-accent: #2563eb;        /* azul ações */
-  --color-warning: #facc15;       /* amarelo alerta */
-  --color-danger: #dc2626;        /* vermelho crítico */
-  --color-muted: #6b7280;         /* cinza secundário */
-  --color-text: #0f172a;          /* texto padrão */
-}
-
 /* Lista de alertas */
 .alert-list {
   list-style: none;

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -1,14 +1,3 @@
-:root {
-  --color-primary: #16a34a;       /* verde segurança */
-  --color-primary-dark: #065f46;  /* verde institucional */
-  --color-accent: #2563eb;        /* azul ações */
-  --color-warning: #facc15;       /* amarelo alerta */
-  --color-danger: #dc2626;        /* vermelho crítico */
-  --color-muted: #6b7280;         /* cinza secundário */
-  --color-bg-dark: rgba(8, 16, 24, 0.95);
-  --color-bg-dark-alt: rgba(7, 21, 28, 0.92);
-}
-
 /* Container geral */
 .auth {
   min-height: 100vh;

--- a/frontend/src/styles/MateriaisPage.css
+++ b/frontend/src/styles/MateriaisPage.css
@@ -1,16 +1,6 @@
-:root {
-  --color-primary: #16a34a;       /* verde segurança */
-  --color-primary-dark: #065f46;  /* verde institucional */
-  --color-accent: #2563eb;        /* azul ações */
-  --color-warning: #facc15;       /* amarelo alerta */
-  --color-danger: #dc2626;        /* vermelho crítico */
-  --color-muted: #6b7280;         /* cinza secundário */
-  --color-history-bg: rgba(148, 163, 184, 0.08);
-}
-
 /* Histórico */
 .data-table__history {
-  background: var(--color-history-bg);
+  background: var(--color-bg-alt);
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
 }

--- a/frontend/src/styles/SystemStatus.css
+++ b/frontend/src/styles/SystemStatus.css
@@ -1,13 +1,3 @@
-:root {
-  --color-primary: #16a34a;       /* verde segurança */
-  --color-primary-dark: #065f46;  /* verde institucional */
-  --color-accent: #2563eb;        /* azul ações */
-  --color-warning: #facc15;       /* amarelo alerta */
-  --color-danger: #dc2626;        /* vermelho crítico */
-  --color-muted: #6b7280;         /* cinza secundário */
-  --color-bg-dark: rgba(15, 23, 42, 0.12);
-}
-
 /* Container principal */
 .system-status {
   display: flex;


### PR DESCRIPTION
## Summary
- remove page-specific :root blocks so styles consume the shared variables bundle
- update the materiais history background to use an existing shared color token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84c5969b083228ecc0a43e6b76e65