### PR TITLE
refactor: prefix page-specific css selectors

### DIFF
--- a/frontend/src/components/Materiais/MateriaisActions.jsx
+++ b/frontend/src/components/Materiais/MateriaisActions.jsx
@@ -14,10 +14,10 @@ export function MateriaisActions({
 
   // Evita renderizar ações para materiais inexistentes
   return (
-    <div className="data-table__actions">
+    <div className="materiais-data-table__actions">
       <button
         type="button"
-        className="table-action-button"
+        className="materiais-table-action-button"
         onClick={() => onEdit(material)}
         disabled={isEditDisabled}
         aria-label={isEditDisabled ? 'Editando material' : `Editar ${material.nome}`}
@@ -26,7 +26,7 @@ export function MateriaisActions({
       </button>
       <button
         type="button"
-        className="table-action-button"
+        className="materiais-table-action-button"
         onClick={() => onHistory(material)}
         disabled={historyDisabled}
         aria-label={`Ver historico de precos de ${material.nome}`}

--- a/frontend/src/components/Materiais/MateriaisHistoricoTimeline.jsx
+++ b/frontend/src/components/Materiais/MateriaisHistoricoTimeline.jsx
@@ -6,7 +6,7 @@ export function MateriaisHistoricoTimeline({ registros }) {
   }
 
   return (
-    <ul className="history-list">
+    <ul className="materiais-history-list">
       {registros.map((registro) => (
         <li key={registro.id}>
           <span>{new Date(registro.dataRegistro).toLocaleString('pt-BR')}</span>

--- a/frontend/src/components/Materiais/MateriaisHistoryModal.jsx
+++ b/frontend/src/components/Materiais/MateriaisHistoryModal.jsx
@@ -15,25 +15,25 @@ export function MateriaisHistoryModal({ modal, onClose }) {
 
   return (
     <div
-      className="record-history__overlay"
+      className="materiais-record-history__overlay"
       role="dialog"
       aria-modal="true"
       aria-labelledby="record-history-title"
       onClick={handleOverlayClick}
     >
-      <div className="record-history__modal" onClick={stopPropagation}>
-        <header className="record-history__header">
+      <div className="materiais-record-history__modal" onClick={stopPropagation}>
+        <header className="materiais-record-history__header">
           <h3 id="record-history-title">Historico de precos - {modal.material?.nome}</h3>
           <button
             type="button"
-            className="record-history__close"
+            className="materiais-record-history__close"
             onClick={onClose}
             aria-label="Fechar historico"
           >
             x
           </button>
         </header>
-        <div className="record-history__body">
+        <div className="materiais-record-history__body">
           {modal.isLoading ? (
             <p className="feedback">Carregando historico...</p>
           ) : modal.error ? (

--- a/frontend/src/components/Pessoas/PessoasActions.jsx
+++ b/frontend/src/components/Pessoas/PessoasActions.jsx
@@ -5,10 +5,10 @@ export function PessoasActions({ pessoa, isEditing, isSaving, onEdit, onHistory,
   const disableHistory = isHistoryLoading || isSaving
 
   return (
-    <div className="data-table__actions">
+    <div className="materiais-data-table__actions">
       <button
         type="button"
-        className="table-action-button"
+        className="materiais-table-action-button"
         onClick={() => onEdit(pessoa)}
         disabled={disableEdit}
         aria-label={disableEdit ? 'Editando pessoa' : `Editar ${pessoa.nome}`}
@@ -17,7 +17,7 @@ export function PessoasActions({ pessoa, isEditing, isSaving, onEdit, onHistory,
       </button>
       <button
         type="button"
-        className="table-action-button"
+        className="materiais-table-action-button"
         onClick={() => onHistory(pessoa)}
         disabled={disableHistory}
         aria-label={`Ver historico de edicao de ${pessoa.nome}`}

--- a/frontend/src/components/Pessoas/PessoasHistoryModal.jsx
+++ b/frontend/src/components/Pessoas/PessoasHistoryModal.jsx
@@ -15,25 +15,25 @@ export function PessoasHistoryModal({ state, onClose }) {
 
   return (
     <div
-      className="record-history__overlay"
+      className="materiais-record-history__overlay"
       role="dialog"
       aria-modal="true"
       aria-labelledby="pessoa-history-title"
       onClick={handleOverlayClick}
     >
-      <div className="record-history__modal" onClick={stopPropagation}>
-        <header className="record-history__header">
+      <div className="materiais-record-history__modal" onClick={stopPropagation}>
+        <header className="materiais-record-history__header">
           <h3 id="pessoa-history-title">Historico de edicoes - {state.pessoa?.nome}</h3>
           <button
             type="button"
-            className="record-history__close"
+            className="materiais-record-history__close"
             onClick={onClose}
             aria-label="Fechar historico"
           >
             x
           </button>
         </header>
-        <div className="record-history__body">
+        <div className="materiais-record-history__body">
           {state.isLoading ? (
             <p className="feedback">Carregando historico...</p>
           ) : state.error ? (

--- a/frontend/src/components/Pessoas/PessoasHistoryTimeline.jsx
+++ b/frontend/src/components/Pessoas/PessoasHistoryTimeline.jsx
@@ -15,7 +15,7 @@ export function PessoasHistoryTimeline({ registros }) {
   }
 
   return (
-    <ul className="history-list">
+    <ul className="materiais-history-list">
       {registros
         .slice()
         .sort((a, b) => new Date(b.dataEdicao) - new Date(a.dataEdicao))

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -287,34 +287,34 @@ export function DashboardPage() {
 
       <div className="dashboard-highlights">
         {highlightCards.map(({ id, title, value, helper, icon: IconComponent, tone }) => (
-          <article key={id} className={`insight-card insight-card--${tone}`}>
-            <header className="insight-card__header">
-              <p className="insight-card__title">{title}</p>
-              <span className="insight-card__avatar">
+          <article key={id} className={`dashboard-insight-card dashboard-insight-card--${tone}`}>
+            <header className="dashboard-insight-card__header">
+              <p className="dashboard-insight-card__title">{title}</p>
+              <span className="dashboard-insight-card__avatar">
                 <IconComponent size={22} />
               </span>
             </header>
-            <strong className="insight-card__value">{value}</strong>
-            <span className="insight-card__helper">{helper}</span>
+            <strong className="dashboard-insight-card__value">{value}</strong>
+            <span className="dashboard-insight-card__helper">{helper}</span>
           </article>
         ))}
       </div>
 
       <div className="dashboard-grid dashboard-grid--two">
-        <section className="card card--chart card--chart-lg">
-          <header className="card__header">
-            <h2 className="card__title"><BarsIcon size={20} /> <span>Entradas x Saidas</span></h2>
+        <section className="card dashboard-card--chart dashboard-card--chart-lg">
+          <header className="card__header dashboard-card__header">
+            <h2 className="dashboard-card__title"><BarsIcon size={20} /> <span>Entradas x Saidas</span></h2>
           </header>
-          <div className="chart-container">
+          <div className="dashboard-chart-container">
             <EntradasSaidasChart data={seriesHistorica} labelFormatter={formatPeriodoLabel} />
           </div>
         </section>
 
-        <section className="card card--chart card--chart-lg">
-          <header className="card__header">
-            <h2 className="card__title"><RevenueIcon size={20} /> <span>Valor movimentado</span></h2>
+        <section className="card dashboard-card--chart dashboard-card--chart-lg">
+          <header className="card__header dashboard-card__header">
+            <h2 className="dashboard-card__title"><RevenueIcon size={20} /> <span>Valor movimentado</span></h2>
           </header>
-          <div className="chart-container">
+          <div className="dashboard-chart-container">
             <ValorMovimentadoChart
               data={seriesHistorica.map(({ periodo, valorEntradas, valorSaidas }) => ({ periodo, valorEntradas, valorSaidas }))}
               valueFormatter={formatCurrency}
@@ -324,30 +324,30 @@ export function DashboardPage() {
       </div>
 
       <div className="dashboard-grid dashboard-grid--two">
-        <section className="card card--chart card--chart-lg">
-          <header className="card__header">
-            <h2 className="card__title"><StockIcon size={20} /> <span>Estoque por material</span></h2>
+        <section className="card dashboard-card--chart dashboard-card--chart-lg">
+          <header className="card__header dashboard-card__header">
+            <h2 className="dashboard-card__title"><StockIcon size={20} /> <span>Estoque por material</span></h2>
           </header>
-          <div className="chart-container">
+          <div className="dashboard-chart-container">
             <EstoquePorMaterialChart data={estoquePorMaterial.slice(0, 8)} />
           </div>
         </section>
 
-        <section className="card card--chart card--chart-lg">
-          <header className="card__header">
-            <h2 className="card__title"><PieIcon size={20} /> <span>Estoque por categoria</span></h2>
+        <section className="card dashboard-card--chart dashboard-card--chart-lg">
+          <header className="card__header dashboard-card__header">
+            <h2 className="dashboard-card__title"><PieIcon size={20} /> <span>Estoque por categoria</span></h2>
           </header>
-          <div className="chart-container">
+          <div className="dashboard-chart-container">
             <EstoquePorCategoriaChart data={estoquePorCategoria} />
           </div>
         </section>
       </div>
 
-      <section className="card card--wide">
-        <header className="card__header">
-          <h2 className="card__title"><TrendIcon size={20} /> <span>Top materiais movimentados</span></h2>
+      <section className="card dashboard-card--wide">
+        <header className="card__header dashboard-card__header">
+          <h2 className="dashboard-card__title"><TrendIcon size={20} /> <span>Top materiais movimentados</span></h2>
         </header>
-        <div className="chart-container">
+        <div className="dashboard-chart-container">
           <MateriaisMaisUsadosChart data={rankingMateriais.slice(0, 8)} />
         </div>
       </section>

--- a/frontend/src/pages/EstoquePage.jsx
+++ b/frontend/src/pages/EstoquePage.jsx
@@ -101,7 +101,7 @@ export function EstoquePage() {
 
     const parsed = Number(draftValue)
     if (Number.isNaN(parsed) || parsed < 0) {
-      setMinStockErrors((prev) => ({ ...prev, [item.materialId]: 'Valor inv·lido' }))
+      setMinStockErrors((prev) => ({ ...prev, [item.materialId]: 'Valor inv√°lido' }))
       return
     }
 
@@ -196,18 +196,18 @@ export function EstoquePage() {
           <h2>Alertas de estoque</h2>
         </header>
         {alertasFiltrados.length ? (
-          <ul className="alert-list">
+          <ul className="estoque-alert-list">
             {alertasFiltrados.map((alerta) => {
               const deficit = Math.max(Number(alerta.estoqueMinimo ?? 0) - Number(alerta.estoqueAtual ?? 0), 0)
               return (
-                <li key={alerta.materialId} className="alert-list__item">
-                  <span className="badge badge--alert">{alerta.nome?.split(' ')[0] || 'Material'}</span>
+                <li key={alerta.materialId} className="estoque-alert-list__item">
+                  <span className="estoque-badge estoque-badge--alert">{alerta.nome?.split(' ')[0] || 'Material'}</span>
                   <span>
                     Estoque atual: <strong>{alerta.estoqueAtual}</strong>
                     {' '}| Minimo: <strong>{alerta.estoqueMinimo}</strong>
-                    {deficit > 0 ? <span className="alert-list__deficit"> - faltam {deficit}</span> : null}
+                    {deficit > 0 ? <span className="estoque-alert-list__deficit"> - faltam {deficit}</span> : null}
                   </span>
-                  <span className="alert-list__material">{alerta.nome} - {alerta.fabricante}</span>
+                  <span className="estoque-alert-list__material">{alerta.nome} - {alerta.fabricante}</span>
                 </li>
               )
             })}
@@ -229,23 +229,23 @@ export function EstoquePage() {
           <h2>Itens</h2>
         </header>
         {itensFiltrados.length === 0 ? <p className="feedback">Sem materiais cadastrados ou filtrados.</p> : null}
-        <div className="list">
+        <div className="estoque-list">
           {itensFiltrados.map((item) => {
             const draftValue = minStockDrafts[item.materialId] ?? ''
             const isSavingMin = Boolean(savingMinStock[item.materialId])
             const fieldError = minStockErrors[item.materialId]
             return (
-              <article key={item.materialId} className={`list__item${item.alerta ? ' list__item--alert' : ''}`}>
-                <header className="list__item-header">
+              <article key={item.materialId} className={`estoque-list__item${item.alerta ? ' estoque-list__item--alert' : ''}`}>
+                <header className="estoque-list__item-header">
                   <div>
                     <h3>{item.nome}</h3>
                     <p>{item.fabricante}</p>
                   </div>
-                  <div className="list__item-meta">
+                  <div className="estoque-list__item-meta">
                     <span>Quantidade: {item.quantidade}</span>
                     <span>Valor unitario: {formatCurrency(item.valorUnitario)}</span>
                     <span>Valor total: {formatCurrency(item.valorTotal)}</span>
-                    <div className="list__item-min-stock">
+                    <div className="estoque-list__item-min-stock">
                       <label>
                         <span>Estoque minimo</span>
                         <input
@@ -265,10 +265,10 @@ export function EstoquePage() {
                         {isSavingMin ? 'Salvando...' : 'Salvar'}
                       </button>
                     </div>
-                    {fieldError ? <span className="list__item-error">{fieldError}</span> : null}
+                    {fieldError ? <span className="estoque-list__item-error">{fieldError}</span> : null}
                   </div>
                 </header>
-                <div className="list__item-body">
+                <div className="estoque-list__item-body">
                   <span>Validade (dias): {item.validadeDias}</span>
                   <span>CA: {item.ca}</span>
                 </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -53,19 +53,19 @@ export function LoginPage() {
   }
 
   return (
-    <div className="auth auth--login">
-      <form className="auth-card auth-card--neon" onSubmit={handleSubmit}>
-        <div className="auth-card__logo">
+    <div className="login-auth login-auth--login">
+      <form className="login-auth-card login-auth-card--neon" onSubmit={handleSubmit}>
+        <div className="login-auth-card__logo">
           <img src={logoSrc} alt="EpicControl" />
         </div>
 
-        <header className="auth-card__titles">
-          <p className="auth-card__subtitle">Bem-vindo de volta. Acesse o sistema para registrar entrega ou devolucao de EPI.</p>
+        <header className="login-auth-card__titles">
+          <p className="login-auth-card__subtitle">Bem-vindo de volta. Acesse o sistema para registrar entrega ou devolucao de EPI.</p>
         </header>
 
-        <label className="field field--panel">
+        <label className="field login-field--panel">
           <span>Email</span>
-          <div className="field__panel">
+          <div className="login-field__panel">
             <BadgeIcon />
             <input
               type="text"
@@ -79,9 +79,9 @@ export function LoginPage() {
           </div>
         </label>
 
-        <label className="field field--panel">
+        <label className="field login-field--panel">
           <span>Senha</span>
-          <div className="field__panel">
+          <div className="login-field__panel">
             <LockIcon />
             <input
               type="password"
@@ -97,19 +97,19 @@ export function LoginPage() {
 
         {error ? <p className="feedback feedback--error">{error}</p> : null}
 
-        <div className="auth-card__options">
-          <label className="checkbox">
+        <div className="login-auth-card__options">
+          <label className="login-checkbox">
             <input type="checkbox" name="remember" checked={form.remember} onChange={handleChange} />
             <span>Manter conectado</span>
           </label>
           <button type="button" className="link-button">Esqueceu a senha?</button>
         </div>
 
-        <button type="submit" className="button button--neon" disabled={isSubmitting}>
+        <button type="submit" className="button login-button--neon" disabled={isSubmitting}>
           {isSubmitting ? 'Entrando...' : 'Entrar'}
         </button>
 
-        <footer className="auth-card__footer">
+        <footer className="login-auth-card__footer">
           <p>Seu EPI e sua protecao. Registre corretamente cada movimentacao.</p>
         </footer>
       </form>

--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -5,7 +5,7 @@
   gap: 1.5rem;
 }
 
-.insight-card {
+.dashboard-insight-card {
   position: relative;
   padding: 1.5rem;
   border-radius: 1.4rem;
@@ -19,7 +19,7 @@
   overflow: hidden;
 }
 
-.insight-card::after {
+.dashboard-insight-card::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -29,25 +29,25 @@
 }
 
 /* cabeçalho */
-.insight-card__header {
+.dashboard-insight-card__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.insight-card__title {
+.dashboard-insight-card__title {
   font-size: 0.95rem;
   font-weight: 600;
   color: #0f172a;
 }
 
-.insight-card__value {
+.dashboard-insight-card__value {
   font-size: 2rem;
   font-weight: 700;
   color: #0f172a;
 }
 
-.insight-card__helper {
+.dashboard-insight-card__helper {
   font-size: 0.9rem;
   color: var(--color-muted);
   display: inline-flex;
@@ -55,7 +55,7 @@
   gap: 0.35rem;
 }
 
-.insight-card__avatar {
+.dashboard-insight-card__avatar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -67,38 +67,53 @@
 }
 
 /* VARIANTES DE CORES */
-.insight-card--blue::after {
+.dashboard-insight-card--blue::after {
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.6), rgba(165, 180, 252, 0.4));
 }
-.insight-card--blue .insight-card__avatar { background: rgba(37, 99, 235, 0.12); color: var(--color-accent); }
-.insight-card--blue .insight-card__helper { color: var(--color-accent); }
+.dashboard-insight-card--blue .dashboard-insight-card__avatar {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-accent);
+}
+.dashboard-insight-card--blue .dashboard-insight-card__helper { color: var(--color-accent); }
 
-.insight-card--green::after {
+.dashboard-insight-card--green::after {
   background: linear-gradient(135deg, rgba(22, 163, 74, 0.55), rgba(16, 185, 129, 0.35));
 }
-.insight-card--green .insight-card__avatar { background: rgba(16, 185, 129, 0.12); color: var(--color-primary-dark); }
-.insight-card--green .insight-card__helper { color: var(--color-primary); }
+.dashboard-insight-card--green .dashboard-insight-card__avatar {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--color-primary-dark);
+}
+.dashboard-insight-card--green .dashboard-insight-card__helper { color: var(--color-primary); }
 
-.insight-card--orange::after {
+.dashboard-insight-card--orange::after {
   background: linear-gradient(135deg, rgba(249, 115, 22, 0.55), rgba(251, 191, 36, 0.35));
 }
-.insight-card--orange .insight-card__avatar { background: rgba(249, 115, 22, 0.12); color: #f97316; }
-.insight-card--orange .insight-card__helper { color: #f97316; }
+.dashboard-insight-card--orange .dashboard-insight-card__avatar {
+  background: rgba(249, 115, 22, 0.12);
+  color: #f97316;
+}
+.dashboard-insight-card--orange .dashboard-insight-card__helper { color: #f97316; }
 
-.insight-card--red::after {
+.dashboard-insight-card--red::after {
   background: linear-gradient(135deg, rgba(220, 38, 38, 0.55), rgba(239, 68, 68, 0.35));
 }
-.insight-card--red .insight-card__avatar { background: rgba(220, 38, 38, 0.12); color: var(--color-danger); }
-.insight-card--red .insight-card__helper { color: var(--color-danger); }
+.dashboard-insight-card--red .dashboard-insight-card__avatar {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-danger);
+}
+.dashboard-insight-card--red .dashboard-insight-card__helper { color: var(--color-danger); }
 
-.insight-card--slate::after {
+.dashboard-insight-card--slate::after {
   background: linear-gradient(135deg, rgba(148, 163, 184, 0.45), rgba(226, 232, 240, 0.35));
 }
-.insight-card--slate .insight-card__avatar { background: rgba(148, 163, 184, 0.12); color: #475569; }
-.insight-card--slate .insight-card__helper { color: #475569; }
+.dashboard-insight-card--slate .dashboard-insight-card__avatar {
+  background: rgba(148, 163, 184, 0.12);
+  color: #475569;
+}
+.dashboard-insight-card--slate .dashboard-insight-card__helper { color: #475569; }
 
 /* TITULOS */
-.card__title {
+.dashboard-card__title {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -107,7 +122,7 @@
   color: #0f172a;
 }
 
-.card__title svg {
+.dashboard-card__title svg {
   color: var(--color-accent);
 }
 
@@ -122,7 +137,7 @@
   align-items: stretch;
 }
 
-.card--chart {
+.dashboard-card--chart {
   display: flex;
   flex-direction: column;
   min-height: 320px;
@@ -134,25 +149,25 @@
   box-shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
 }
 
-.card__header { margin-bottom: 0.75rem; }
+.dashboard-card__header { margin-bottom: 0.75rem; }
 
-.card--chart > *:last-child {
+.dashboard-card--chart > *:last-child {
   flex: 1;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.card--chart .recharts-responsive-container {
+.dashboard-card--chart .recharts-responsive-container {
   width: 100% !important;
   height: 100% !important;
 }
 
-.card--chart-lg { min-height: 420px; }
-.card--chart-lg > *:last-child { align-items: center; }
-.card--wide { gap: 1.5rem; }
+.dashboard-card--chart-lg { min-height: 420px; }
+.dashboard-card--chart-lg > *:last-child { align-items: center; }
+.dashboard-card--wide { gap: 1.5rem; }
 
-.chart-container {
+.dashboard-chart-container {
   flex: 1;
   width: 100%;
   height: 100%;
@@ -166,5 +181,5 @@
 
 @media (max-width: 640px) {
   .dashboard-highlights { grid-template-columns: 1fr; }
-  .card--chart { min-height: 280px; }
+  .dashboard-card--chart { min-height: 280px; }
 }

--- a/frontend/src/styles/EstoquePage.css
+++ b/frontend/src/styles/EstoquePage.css
@@ -1,5 +1,5 @@
 /* Lista de alertas */
-.alert-list {
+.estoque-alert-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -8,7 +8,7 @@
   gap: 0.75rem;
 }
 
-.alert-list__item {
+.estoque-alert-list__item {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -18,18 +18,18 @@
   border: 1px solid rgba(220, 38, 38, 0.25);
 }
 
-.alert-list__material {
+.estoque-alert-list__material {
   font-size: 0.85rem;
   color: rgba(71, 85, 105, 0.85);
 }
 
-.alert-list__deficit {
+.estoque-alert-list__deficit {
   color: var(--color-danger);
   font-weight: 600;
 }
 
 /* Badge */
-.badge {
+.estoque-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -43,26 +43,26 @@
   color: var(--color-primary-dark);
 }
 
-.badge--alert {
+.estoque-badge--alert {
   background: rgba(250, 204, 21, 0.25); /* amarelo alerta */
   color: #92400e;
   border: 1px solid rgba(250, 204, 21, 0.6);
 }
 
-.badge--critical {
+.estoque-badge--critical {
   background: rgba(220, 38, 38, 0.2); /* vermelho crítico */
   color: #b91c1c;
   border: 1px solid rgba(220, 38, 38, 0.4);
 }
 
 /* Lista genérica */
-.list {
+.estoque-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.list__item {
+.estoque-list__item {
   background: rgba(248, 250, 252, 0.95);
   border-radius: 1rem;
   padding: 1.25rem;
@@ -72,34 +72,34 @@
   gap: 0.75rem;
 }
 
-.list__item--alert {
+.estoque-list__item--alert {
   border-color: rgba(250, 204, 21, 0.6); /* amarelo */
   box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.25);
 }
 
-.list__item--critical {
+.estoque-list__item--critical {
   border-color: rgba(220, 38, 38, 0.6); /* vermelho crítico */
   box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.25);
 }
 
-.list__item-header {
+.estoque-list__item-header {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
 }
 
-.list__item-header h3 {
+.estoque-list__item-header h3 {
   font-size: 1.1rem;
   color: var(--color-text);
 }
 
-.list__item-header p {
+.estoque-list__item-header p {
   color: var(--color-muted);
   font-size: 0.9rem;
 }
 
-.list__item-meta {
+.estoque-list__item-meta {
   display: flex;
   gap: 0.5rem 1.5rem;
   color: var(--color-muted);
@@ -107,7 +107,7 @@
   flex-wrap: wrap;
 }
 
-.list__item-body {
+.estoque-list__item-body {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
@@ -115,14 +115,14 @@
   font-size: 0.9rem;
 }
 
-.list__item-min-stock {
+.estoque-list__item-min-stock {
   display: flex;
   align-items: flex-end;
   gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-.list__item-min-stock label {
+.estoque-list__item-min-stock label {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
@@ -130,19 +130,19 @@
   color: var(--color-text);
 }
 
-.list__item-min-stock input {
+.estoque-list__item-min-stock input {
   width: 6rem;
 }
 
-.list__item-min-stock button {
+.estoque-list__item-min-stock button {
   padding: 0.35rem 0.75rem;
 }
 
-.list__item-error {
+.estoque-list__item-error {
   color: var(--color-danger);
   font-size: 0.8rem;
 }
-.list__item-error::before {
+.estoque-list__item-error::before {
   content: '⚠️';
   margin-right: 0.25rem;
 }

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -1,5 +1,5 @@
 /* Container geral */
-.auth {
+.login-auth {
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -9,7 +9,7 @@
 }
 
 /* Card */
-.auth-card {
+.login-auth-card {
   width: min(420px, 100%);
   background: linear-gradient(160deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
   border-radius: 1.5rem;
@@ -23,7 +23,7 @@
   position: relative;
 }
 
-.auth-card--neon::before {
+.login-auth-card--neon::before {
   content: '';
   position: absolute;
   inset: -16px;
@@ -35,13 +35,13 @@
 }
 
 /* Logo */
-.auth-card__logo {
+.login-auth-card__logo {
   display: flex;
   justify-content: center;
   margin-bottom: 0.65rem;
 }
 
-.auth-card__logo img {
+.login-auth-card__logo img {
   max-width: 140px;
   width: 100%;
   height: auto;
@@ -49,45 +49,45 @@
 }
 
 /* Títulos */
-.auth-card__titles {
+.login-auth-card__titles {
   text-align: center;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.auth-card__kicker {
+.login-auth-card__kicker {
   font-size: 0.95rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
   color: rgba(148, 163, 184, 0.9);
 }
 
-.auth-card__titles h1 {
+.login-auth-card__titles h1 {
   font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 700;
   color: #e2f2ff;
 }
 
-.auth-card__subtitle {
+.login-auth-card__subtitle {
   color: rgba(191, 219, 254, 0.82);
   font-size: 0.9rem;
 }
 
 /* Campos */
-.field--panel {
+.login-field--panel {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
 }
 
-.field--panel span {
+.login-field--panel span {
   font-size: 0.85rem;
   font-weight: 500;
   color: rgba(226, 232, 240, 0.8);
 }
 
-.field__panel {
+.login-field__panel {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -98,13 +98,13 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.field__panel svg {
+.login-field__panel svg {
   width: 1.05rem;
   height: 1.05rem;
   color: var(--color-primary); /* ícone verde */
 }
 
-.field__panel input {
+.login-field__panel input {
   border: none;
   background: transparent;
   flex: 1;
@@ -112,17 +112,17 @@
   font-size: 0.95rem;
 }
 
-.field__panel input::placeholder {
+.login-field__panel input::placeholder {
   color: rgba(100, 116, 139, 0.65);
 }
 
-.field__panel:focus-within {
+.login-field__panel:focus-within {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
 }
 
 /* Opções */
-.auth-card__options {
+.login-auth-card__options {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -132,18 +132,18 @@
   gap: 0.5rem;
 }
 
-.checkbox {
+.login-checkbox {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
 }
 
-.checkbox input {
+.login-checkbox input {
   accent-color: var(--color-accent); /* azul */
 }
 
 /* Botão principal */
-.button--neon {
+.login-button--neon {
   width: 100%;
   border: none;
   border-radius: 0.9rem;
@@ -155,12 +155,12 @@
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.button--neon:hover:not(:disabled) {
+.login-button--neon:hover:not(:disabled) {
   transform: translateY(-2px);
 }
 
 /* Rodapé */
-.auth-card__footer {
+.login-auth-card__footer {
   text-align: center;
   font-size: 0.82rem;
   color: rgba(226, 232, 240, 0.72);
@@ -171,12 +171,12 @@
 
 /* Responsivo */
 @media (max-width: 640px) {
-  .auth-card {
+  .login-auth-card {
     padding: 2rem 1.75rem;
     border-radius: 1.25rem;
   }
 
-  .auth-card__titles h1 {
+  .login-auth-card__titles h1 {
     font-size: 2rem;
   }
 }

--- a/frontend/src/styles/MateriaisPage.css
+++ b/frontend/src/styles/MateriaisPage.css
@@ -1,11 +1,11 @@
 /* Histórico */
-.data-table__history {
+.materiais-data-table__history {
   background: var(--color-bg-alt);
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
 }
 
-.history-list {
+.materiais-history-list {
   list-style: none;
   margin: 0;
   padding: 0.5rem 0;
@@ -14,7 +14,7 @@
   gap: 0.35rem;
 }
 
-.history-list li {
+.materiais-history-list li {
   display: flex;
   gap: 1.25rem;
   font-size: 0.85rem;
@@ -23,29 +23,29 @@
 }
 
 /* Variantes para destacar status no histórico */
-.history-list li.ok {
+.materiais-history-list li.ok {
   color: var(--color-primary-dark); /* estoque normal */
   font-weight: 600;
 }
 
-.history-list li.warning {
+.materiais-history-list li.warning {
   color: var(--color-warning); /* estoque baixo */
   font-weight: 600;
 }
 
-.history-list li.danger {
+.materiais-history-list li.danger {
   color: var(--color-danger); /* crítico */
   font-weight: 600;
 }
 
 /* Ações */
-.data-table__actions {
+.materiais-data-table__actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.table-action-button {
+.materiais-table-action-button {
   border: none;
   background: rgba(37, 99, 235, 0.12);
   color: var(--color-accent);
@@ -59,22 +59,22 @@
   transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
 }
 
-.table-action-button:hover,
-.table-action-button:focus-visible {
+.materiais-table-action-button:hover,
+.materiais-table-action-button:focus-visible {
   background: var(--color-accent);
   color: #fff;
   transform: translateY(-1px);
   outline: none;
 }
 
-.table-action-button:disabled {
+.materiais-table-action-button:disabled {
   opacity: 0.45;
   cursor: not-allowed;
   transform: none;
 }
 
 
-.record-history__overlay {
+.materiais-record-history__overlay {
   position: fixed;
   inset: 0;
   background: rgba(15, 23, 42, 0.55);
@@ -85,7 +85,7 @@
   z-index: 1000;
 }
 
-.record-history__modal {
+.materiais-record-history__modal {
   background: var(--color-card, #fff);
   border-radius: 1rem;
   width: min(520px, 100%);
@@ -97,19 +97,19 @@
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.25);
 }
 
-.record-history__header {
+.materiais-record-history__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
 }
 
-.record-history__header h3 {
+.materiais-record-history__header h3 {
   margin: 0;
   font-size: 1.05rem;
 }
 
-.record-history__close {
+.materiais-record-history__close {
   border: none;
   background: transparent;
   color: var(--color-muted);
@@ -123,19 +123,19 @@
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-.record-history__close:hover,
-.record-history__close:focus-visible {
+.materiais-record-history__close:hover,
+.materiais-record-history__close:focus-visible {
   background: rgba(148, 163, 184, 0.2);
   color: var(--color-primary-dark);
   outline: none;
 }
 
-.record-history__body {
+.materiais-record-history__body {
   max-height: 60vh;
   overflow-y: auto;
   padding-right: 0.25rem;
 }
 
-.record-history__body .history-list {
+.materiais-record-history__body .materiais-history-list {
   gap: 0.6rem;
 }


### PR DESCRIPTION
## Summary
- prefix the dashboard insight, chart and layout selectors and update the dashboard page to match the new class names
- namespace the estoque alert and list styles plus the login form styles and align their React components with the new prefixes
- namespace materiais history/list/action styles and update materiais and pessoas components that rely on them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86140e19083229f9e089d10173245