### PR TITLE
Atualiza classes de layout do sidebar

### DIFF
--- a/frontend/src/layouts/MainLayout.jsx
+++ b/frontend/src/layouts/MainLayout.jsx
@@ -8,17 +8,17 @@ const logoSrc = '/proteg.png'
 export function MainLayout() {
   return (
     <div className="layout">
-      <aside className="layout__sidebar">
-        <div className="layout__brand">
-          <img src={logoSrc} alt="EpicControl" className="layout__brand-image" />
-          <div className="layout__brand-text">
+      <aside className="sidebar sidebar--expanded">
+        <div className="sidebar__brand">
+          <img src={logoSrc} alt="EpicControl" className="sidebar__brand-image" />
+          <div className="sidebar__brand-text">
           </div>
         </div>
         <NavBar />
-        <SystemStatus className="layout__system-status" />
+        <SystemStatus className="sidebar__system-status" />
       </aside>
-      <div className="layout__content">
-        <main className="layout__main">
+      <div className="layout-content">
+        <main className="layout-main">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -7,7 +7,7 @@
   color: var(--color-text);
 }
 
-.layout__sidebar {
+aside.sidebar {
   position: sticky;
   top: 0;
   height: 100vh;
@@ -21,49 +21,48 @@
   box-sizing: border-box;
 }
 
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.sidebar--expanded {
+  width: 100%;
+  max-width: 320px;
 }
 
-.layout__system-status {
+.sidebar__system-status {
   margin-top: auto;
   width: 100%;
 }
 
-.layout__brand {
+.sidebar__brand {
   display: flex;
   align-items: center;
   gap: 1rem;
 }
 
-.layout__brand-image {
+.sidebar__brand-image {
   width: 92px;
   height: 92px;
   object-fit: cover;
   border-radius: 12px;
 }
 
-.layout__brand-text {
+.sidebar__brand-text {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
 }
 
-.layout__brand-subtitle {
+.sidebar__brand-subtitle {
   font-size: 0.95rem;
   font-weight: 600;
   color: rgba(226, 232, 240, 0.85);
 }
 
-.layout__content {
+.layout-content {
   display: flex;
   flex-direction: column;
   background: var(--color-bg-alt);
 }
 
-.layout__main {
+.layout-main {
   flex: 1;
   padding: 2rem;
   overflow-y: auto;
@@ -74,7 +73,7 @@
     grid-template-columns: 1fr;
   }
 
-  .layout__sidebar {
+  aside.sidebar {
     position: static;
     height: auto;
     overflow-y: visible;
@@ -85,24 +84,24 @@
     padding: 1.5rem;
   }
 
-  .layout__system-status {
+  .sidebar__system-status {
     margin-top: 0;
     flex: 1 1 100%;
   }
 
-  .layout__main {
+  .layout-main {
     padding: 1.5rem;
   }
 }
 
 @media (max-width: 640px) {
-  .layout__main {
+  .layout-main {
     padding: 1.25rem;
   }
 }
 
 /* Sidebar */
-.sidebar {
+nav.sidebar {
   width: 100%;
   max-width: 320px;
   height: 100%;


### PR DESCRIPTION
## Summary
- renomeia as classes do layout para o sidebar e para o conteúdo principal, alinhando os componentes ao novo padrão
- atualiza os seletores e media queries de `layout.css` para refletir os novos nomes e manter a responsividade

## Testing
- rg "layout__" frontend/src

------
https://chatgpt.com/codex/tasks/task_e_68d8685770ec8322a59f17d82f2d55a7