### PR TITLE
Remove unused sidebar styles

### DIFF
--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -50,12 +50,6 @@ aside.sidebar {
   gap: 0.2rem;
 }
 
-.sidebar__brand-subtitle {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.85);
-}
-
 .layout-content {
   display: flex;
   flex-direction: column;
@@ -117,15 +111,6 @@ nav.sidebar {
 .sidebar__section:first-child {
   border-top: none;
   padding-top: 0;
-}
-
-/* Título */
-.sidebar__section-title {
-  font-size: 0.8rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-sidebar-title);
 }
 
 /* Lista */


### PR DESCRIPTION
## Summary
- remove unused sidebar CSS selectors that are no longer referenced
- ensure no components depend on the removed selectors by searching the frontend source

## Testing
- Manual visual inspection of the sidebar navigation

------
https://chatgpt.com/codex/tasks/task_e_68d86bb97db88322a2d35b4c0a21d6d7