### PR TITLE
Consolidate responsive styles in layout stylesheet

### DIFF
--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -173,13 +173,3 @@
   height: 100%;
   display: flex;
 }
-
-/* RESPONSIVO */
-@media (max-width: 900px) {
-  .dashboard-grid--two { grid-template-columns: 1fr; }
-}
-
-@media (max-width: 640px) {
-  .dashboard-highlights { grid-template-columns: 1fr; }
-  .dashboard-card--chart { min-height: 280px; }
-}

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -168,15 +168,3 @@
   flex-direction: column;
   gap: 0.4rem;
 }
-
-/* Responsivo */
-@media (max-width: 640px) {
-  .login-auth-card {
-    padding: 2rem 1.75rem;
-    border-radius: 1.25rem;
-  }
-
-  .login-auth-card__titles h1 {
-    font-size: 2rem;
-  }
-}

--- a/frontend/src/styles/SystemStatus.css
+++ b/frontend/src/styles/SystemStatus.css
@@ -173,9 +173,3 @@
 .system-status__feedback--success {
   color: var(--color-primary);
 }
-
-@media (max-width: 768px) {
-  .system-status {
-    padding: 1.15rem 1.2rem;
-  }
-}

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -240,10 +240,3 @@ ul, ol {
   font-size: 0.78rem;
   color: rgba(100, 116, 139, 0.85);
 }
-
-@media (max-width: 768px) {
-  .form--inline {
-    flex-direction: column;
-    align-items: stretch;
-  }
-}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -238,3 +238,30 @@ nav.sidebar {
 .sidebar__chevron--open {
   transform: rotate(180deg);
 }
+
+/* Responsivo */
+@media (max-width: 640px) {
+  .dashboard-highlights { grid-template-columns: 1fr; }
+  .dashboard-card--chart { min-height: 280px; }
+  .login-auth-card {
+    padding: 2rem 1.75rem;
+    border-radius: 1.25rem;
+  }
+  .login-auth-card__titles h1 {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .form--inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .system-status {
+    padding: 1.15rem 1.2rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .dashboard-grid--two { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- relocate responsive media queries from feature-specific stylesheets into `layout.css`
- organize the moved breakpoints under a unified responsive section ordered by viewport size

## Testing
- `rg "@media" frontend/src/styles`


------
https://chatgpt.com/codex/tasks/task_e_68d8713f1fe08322b6ee522325efa92c