### PR TITLE
Align configuration feedback styles with global utilities

### DIFF
--- a/frontend/src/pages/Configuracoes.jsx
+++ b/frontend/src/pages/Configuracoes.jsx
@@ -125,7 +125,7 @@ function ChangePasswordSection({ user }) {
         </label>
 
         {feedback ? (
-          <p className={`system-status__feedback system-status__feedback--${feedback.type}`}>
+          <p className={`feedback feedback--${feedback.type}`}>
             {feedback.message}
           </p>
         ) : null}

--- a/frontend/src/styles/SystemStatus.css
+++ b/frontend/src/styles/SystemStatus.css
@@ -161,15 +161,3 @@
   transform: translateY(-1px);
 }
 
-.system-status__feedback {
-  margin: 0;
-  font-size: 0.85rem;
-}
-
-.system-status__feedback--error {
-  color: var(--color-danger);
-}
-
-.system-status__feedback--success {
-  color: var(--color-primary);
-}

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -203,6 +203,11 @@ ul, ol {
   font-weight: 500;
 }
 
+.feedback--success {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
 .table-wrapper {
   width: 100%;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- add a global success feedback utility to the shared stylesheet
- switch the configuration page messaging to the shared feedback classes
- remove the obsolete system status feedback styles

## Testing
- rg "system-status__feedback" frontend/src

------
https://chatgpt.com/codex/tasks/task_e_68d872d5db5883228b83ec167785e023