### PR TITLE
Adjust sidebar navigation class naming

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -90,7 +90,7 @@ export function NavBar() {
   }
 
   return (
-    <nav className="sidebar">
+    <nav className="sidebar__nav">
       {navSections.map((section) => {
         const SectionIcon = section.icon
         const isOpen = openSections[section.id]

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -95,7 +95,7 @@ aside.sidebar {
 }
 
 /* Sidebar */
-nav.sidebar {
+.sidebar__nav {
   width: 100%;
   max-width: 320px;
   height: 100%;


### PR DESCRIPTION
## Summary
- rename the NavBar `<nav>` class to `sidebar__nav` to better distinguish it from the base sidebar container
- update the layout stylesheet to use the new `.sidebar__nav` selector while keeping other sidebar modifiers unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d879005f3c83228a79a3d4b54d8989