### PR TITLE
Add acidentes backend support

### DIFF
--- a/backend/src/controllers/acidenteController.js
+++ b/backend/src/controllers/acidenteController.js
@@ -1,0 +1,35 @@
+const { AcidenteService } = require('../services');
+const { mapError } = require('./helpers');
+
+function listar(req, res, next) {
+  try {
+    const acidentes = AcidenteService.listarAcidentes();
+    return res.json(acidentes);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+function criar(req, res, next) {
+  try {
+    const acidente = AcidenteService.criarAcidente(req.body);
+    return res.status(201).json(acidente);
+  } catch (error) {
+    return next(mapError(error));
+  }
+}
+
+function atualizar(req, res, next) {
+  try {
+    const acidente = AcidenteService.atualizarAcidente(req.params.id, req.body);
+    return res.json(acidente);
+  } catch (error) {
+    return next(mapError(error));
+  }
+}
+
+module.exports = {
+  listar,
+  criar,
+  atualizar
+};

--- a/backend/src/models/Acidente.js
+++ b/backend/src/models/Acidente.js
@@ -1,0 +1,43 @@
+class Acidente {
+  constructor({
+    id,
+    matricula,
+    nome,
+    cargo,
+    data,
+    diasPerdidos,
+    diasDebitados,
+    tipo,
+    agente,
+    lesao,
+    parteLesionada,
+    setor,
+    local,
+    cid = null,
+    cat = null,
+    observacao = null,
+    criadoEm = new Date().toISOString(),
+    atualizadoEm = null
+  }) {
+    this.id = id;
+    this.matricula = matricula;
+    this.nome = nome;
+    this.cargo = cargo;
+    this.data = data;
+    this.diasPerdidos = diasPerdidos;
+    this.diasDebitados = diasDebitados;
+    this.tipo = tipo;
+    this.agente = agente;
+    this.lesao = lesao;
+    this.parteLesionada = parteLesionada;
+    this.setor = setor;
+    this.local = local;
+    this.cid = cid;
+    this.cat = cat;
+    this.observacao = observacao;
+    this.criadoEm = criadoEm;
+    this.atualizadoEm = atualizadoEm;
+  }
+}
+
+module.exports = Acidente;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  Acidente: require('./Acidente'),
   Material: require('./Material'),
   PrecoHistorico: require('./PrecoHistorico'),
   Pessoa: require('./Pessoa'),

--- a/backend/src/repositories/AcidenteRepository.js
+++ b/backend/src/repositories/AcidenteRepository.js
@@ -1,0 +1,9 @@
+const BaseRepository = require('./BaseRepository');
+
+class AcidenteRepository extends BaseRepository {
+  constructor() {
+    super('Acidente');
+  }
+}
+
+module.exports = new AcidenteRepository();

--- a/backend/src/repositories/index.js
+++ b/backend/src/repositories/index.js
@@ -3,7 +3,8 @@ module.exports = {
   pessoas: require('./PessoaRepository'),
   entradas: require('./EntradaRepository'),
   saidas: require('./SaidaRepository'),
-  precos: require('./PrecoHistoricoRepository')
+  precos: require('./PrecoHistoricoRepository'),
+  acidentes: require('./AcidenteRepository')
 };
 
 

--- a/backend/src/routes/acidenteRoutes.js
+++ b/backend/src/routes/acidenteRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const controller = require('../controllers/acidenteController');
+
+const router = express.Router();
+
+router.get('/', controller.listar);
+router.post('/', controller.criar);
+router.put('/:id', controller.atualizar);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -5,6 +5,7 @@ const pessoaRoutes = require('./pessoaRoutes')
 const entradaRoutes = require('./entradaRoutes')
 const saidaRoutes = require('./saidaRoutes')
 const estoqueRoutes = require('./estoqueRoutes')
+const acidenteRoutes = require('./acidenteRoutes')
 
 const router = express.Router()
 
@@ -18,5 +19,6 @@ router.use('/pessoas', pessoaRoutes)
 router.use('/entradas', entradaRoutes)
 router.use('/saidas', saidaRoutes)
 router.use('/estoque', estoqueRoutes)
+router.use('/acidentes', acidenteRoutes)
 
 module.exports = router

--- a/backend/src/rules/acidenteRules.js
+++ b/backend/src/rules/acidenteRules.js
@@ -1,0 +1,57 @@
+function validarCampoObrigatorio(valor, mensagem) {
+  if (!valor || !String(valor).trim()) {
+    throw new Error(mensagem);
+  }
+}
+
+function validarDadosObrigatorios({
+  matricula,
+  nome,
+  cargo,
+  tipo,
+  agente,
+  lesao,
+  parteLesionada,
+  setor,
+  local,
+  data
+}) {
+  validarCampoObrigatorio(matricula, 'Matricula obrigatoria');
+  validarCampoObrigatorio(nome, 'Nome obrigatorio');
+  validarCampoObrigatorio(cargo, 'Cargo obrigatorio');
+  validarCampoObrigatorio(tipo, 'Tipo de acidente obrigatorio');
+  validarCampoObrigatorio(agente, 'Agente causador obrigatorio');
+  validarCampoObrigatorio(lesao, 'Lesao obrigatoria');
+  validarCampoObrigatorio(parteLesionada, 'Parte lesionada obrigatoria');
+  validarCampoObrigatorio(setor, 'Setor obrigatorio');
+  validarCampoObrigatorio(local, 'Local obrigatorio');
+  validarCampoObrigatorio(data, 'Data do acidente obrigatoria');
+}
+
+function validarDias({ diasPerdidos, diasDebitados }) {
+  const perdidos = Number(diasPerdidos);
+  const debitados = Number(diasDebitados);
+
+  if (Number.isNaN(perdidos) || perdidos < 0) {
+    throw new Error('Dias perdidos deve ser zero ou positivo');
+  }
+  if (Number.isNaN(debitados) || debitados < 0) {
+    throw new Error('Dias debitados deve ser zero ou positivo');
+  }
+}
+
+function validarData(data) {
+  const valor = data && String(data).trim();
+  if (!valor) {
+    throw new Error('Data do acidente obrigatoria');
+  }
+  if (Number.isNaN(Date.parse(valor))) {
+    throw new Error('Data do acidente invalida');
+  }
+}
+
+module.exports = {
+  validarDadosObrigatorios,
+  validarDias,
+  validarData
+};

--- a/backend/src/rules/index.js
+++ b/backend/src/rules/index.js
@@ -3,7 +3,8 @@ module.exports = {
   pessoaRules: require('./pessoaRules'),
   entradaRules: require('./entradaRules'),
   saidaRules: require('./saidaRules'),
-  estoqueRules: require('./estoqueRules')
+  estoqueRules: require('./estoqueRules'),
+  acidenteRules: require('./acidenteRules')
 };
 
 

--- a/backend/src/services/AcidenteService.js
+++ b/backend/src/services/AcidenteService.js
@@ -1,0 +1,144 @@
+const { v4: uuid } = require('uuid');
+const { Acidente } = require('../models');
+const repositories = require('../repositories');
+const { acidenteRules } = require('../rules');
+
+function sanitizeRequiredString(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function sanitizeUpdatableString(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function sanitizeOptionalString(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed || null;
+}
+
+class AcidenteService {
+  criarAcidente(payload = {}) {
+    const dadosObrigatorios = {
+      matricula: sanitizeRequiredString(payload.matricula),
+      nome: sanitizeRequiredString(payload.nome),
+      cargo: sanitizeRequiredString(payload.cargo),
+      data: sanitizeRequiredString(payload.data),
+      tipo: sanitizeRequiredString(payload.tipo),
+      agente: sanitizeRequiredString(payload.agente),
+      lesao: sanitizeRequiredString(payload.lesao),
+      parteLesionada: sanitizeRequiredString(payload.parteLesionada),
+      setor: sanitizeRequiredString(payload.setor),
+      local: sanitizeRequiredString(payload.local),
+      diasPerdidos: payload.diasPerdidos,
+      diasDebitados: payload.diasDebitados
+    };
+
+    acidenteRules.validarDadosObrigatorios(dadosObrigatorios);
+    acidenteRules.validarData(dadosObrigatorios.data);
+    acidenteRules.validarDias(dadosObrigatorios);
+
+    const acidente = new Acidente({
+      id: uuid(),
+      matricula: dadosObrigatorios.matricula,
+      nome: dadosObrigatorios.nome,
+      cargo: dadosObrigatorios.cargo,
+      data: dadosObrigatorios.data,
+      diasPerdidos: Number(dadosObrigatorios.diasPerdidos),
+      diasDebitados: Number(dadosObrigatorios.diasDebitados),
+      tipo: dadosObrigatorios.tipo,
+      agente: dadosObrigatorios.agente,
+      lesao: dadosObrigatorios.lesao,
+      parteLesionada: dadosObrigatorios.parteLesionada,
+      setor: dadosObrigatorios.setor,
+      local: dadosObrigatorios.local,
+      cid: sanitizeOptionalString(payload.cid) ?? null,
+      cat: sanitizeOptionalString(payload.cat) ?? null,
+      observacao: sanitizeOptionalString(payload.observacao) ?? null
+    });
+
+    repositories.acidentes.create(acidente);
+    return acidente;
+  }
+
+  listarAcidentes() {
+    return repositories.acidentes.findAll();
+  }
+
+  atualizarAcidente(id, payload = {}) {
+    const atual = repositories.acidentes.findById(id);
+    if (!atual) {
+      const error = new Error('Acidente nao encontrado');
+      error.status = 404;
+      throw error;
+    }
+
+    const updates = {};
+
+    const camposObrigatorios = [
+      'matricula',
+      'nome',
+      'cargo',
+      'data',
+      'tipo',
+      'agente',
+      'lesao',
+      'parteLesionada',
+      'setor',
+      'local'
+    ];
+
+    camposObrigatorios.forEach((campo) => {
+      if (payload[campo] !== undefined) {
+        updates[campo] = sanitizeUpdatableString(payload[campo]);
+      }
+    });
+
+    if (payload.diasPerdidos !== undefined) {
+      updates.diasPerdidos = Number(payload.diasPerdidos);
+    }
+
+    if (payload.diasDebitados !== undefined) {
+      updates.diasDebitados = Number(payload.diasDebitados);
+    }
+
+    if (payload.cid !== undefined) {
+      updates.cid = sanitizeOptionalString(payload.cid);
+    }
+
+    if (payload.cat !== undefined) {
+      updates.cat = sanitizeOptionalString(payload.cat);
+    }
+
+    if (payload.observacao !== undefined) {
+      updates.observacao = sanitizeOptionalString(payload.observacao);
+    }
+
+    const merged = { ...atual, ...updates };
+
+    acidenteRules.validarDadosObrigatorios(merged);
+    acidenteRules.validarData(merged.data);
+    acidenteRules.validarDias(merged);
+
+    updates.atualizadoEm = new Date().toISOString();
+
+    const atualizado = repositories.acidentes.update(id, updates);
+    return atualizado;
+  }
+}
+
+module.exports = new AcidenteService();

--- a/backend/src/services/index.js
+++ b/backend/src/services/index.js
@@ -5,4 +5,5 @@ module.exports = {
   SaidaService: require('./SaidaService'),
   EstoqueService: require('./EstoqueService'),
   AuthService: require('./AuthService'),
+  AcidenteService: require('./AcidenteService'),
 }


### PR DESCRIPTION
## Summary
- add the Acidente domain model, repository, and validation rules to store accident records
- implement an Acidente service plus controller to validate and persist accidents
- register the acidentes routes and exports so the in-memory datastore is ready with the rest of the API

## Testing
- `npm run backend:lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68d940c24f4c8322933fc76efb43b735