### PR TITLE
Integra dados de pessoas no serviço de acidentes

### DIFF
--- a/backend/src/repositories/PessoaRepository.js
+++ b/backend/src/repositories/PessoaRepository.js
@@ -8,6 +8,21 @@ class PessoaRepository extends BaseRepository {
   findByNome(nome) {
     return this.findAll().filter((item) => item.nome.toLowerCase() === nome.toLowerCase());
   }
+
+  findByMatricula(matricula) {
+    if (!matricula && matricula !== 0) {
+      return null;
+    }
+
+    const sanitized = String(matricula).trim().toLowerCase();
+    if (!sanitized) {
+      return null;
+    }
+
+    return (
+      this.findAll().find((item) => String(item.matricula ?? '').trim().toLowerCase() === sanitized) || null
+    );
+  }
 }
 
 module.exports = new PessoaRepository();


### PR DESCRIPTION
## Summary
- adiciona busca por matrícula ao PessoaRepository para permitir reuso de dados cadastrados
- atualiza o AcidenteService para hidratar acidentes com informações da pessoa e reforçar validações usando o repositório

## Testing
- npm run backend:lint *(falha: ESLint não possui configuração no projeto)*

------
https://chatgpt.com/codex/tasks/task_e_68d9440612cc8322bcbdcc0f1ab31c51