### PR TITLE
Add accidents management UI and API namespace

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import { EntradasPage } from './pages/EntradasPage.jsx'
 import { SaidasPage } from './pages/SaidasPage.jsx'
 import { EstoquePage } from './pages/EstoquePage.jsx'
 import { DashboardPage } from './pages/DashboardPage.jsx'
+import { AcidentesPage } from './pages/Acidentes.jsx'
 
 function App() {
   return (
@@ -19,11 +20,16 @@ function App() {
         <Route element={<MainLayout />}>
           <Route index element={<DashboardPage />} />
           <Route path="dashboard" element={<DashboardPage />} />
+          <Route path="dashboard/acidentes" element={<AcidentesPage />} />
           <Route path="estoque" element={<EstoquePage />} />
 
           <Route path="cadastros">
             <Route path="pessoas" element={<PessoasPage />} />
             <Route path="materiais" element={<MateriaisPage />} />
+          </Route>
+
+          <Route path="acidentes">
+            <Route path="cadastro" element={<AcidentesPage />} />
           </Route>
 
           <Route path="configuracoes" element={<ConfiguracoesPage />} />

--- a/frontend/src/components/Acidentes/AcidentesFilters.jsx
+++ b/frontend/src/components/Acidentes/AcidentesFilters.jsx
@@ -1,0 +1,56 @@
+export function AcidentesFilters({ filters, tipos, setores, agentes, onChange, onSubmit, onClear }) {
+  return (
+    <form className="form form--inline" onSubmit={onSubmit}>
+      <label className="field">
+        <span>Buscar</span>
+        <input
+          name="termo"
+          value={filters.termo}
+          onChange={onChange}
+          placeholder="Nome, matricula, setor"
+        />
+      </label>
+      <label className="field">
+        <span>Tipo</span>
+        <select name="tipo" value={filters.tipo} onChange={onChange}>
+          <option value="todos">Todos</option>
+          {tipos.map((tipo) => (
+            <option key={tipo} value={tipo}>
+              {tipo}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="field">
+        <span>Setor</span>
+        <select name="setor" value={filters.setor} onChange={onChange}>
+          <option value="todos">Todos</option>
+          {setores.map((setor) => (
+            <option key={setor} value={setor}>
+              {setor}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="field">
+        <span>Agente</span>
+        <select name="agente" value={filters.agente} onChange={onChange}>
+          <option value="todos">Todos</option>
+          {agentes.map((agente) => (
+            <option key={agente} value={agente}>
+              {agente}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="form__actions">
+        <button type="submit" className="button button--ghost">
+          Aplicar
+        </button>
+        <button type="button" className="button button--ghost" onClick={onClear}>
+          Limpar
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/Acidentes/AcidentesForm.jsx
+++ b/frontend/src/components/Acidentes/AcidentesForm.jsx
@@ -1,0 +1,75 @@
+export function AcidentesForm({ form, onChange, onSubmit, isSaving, editingAcidente, onCancel, error }) {
+  return (
+    <form className="form" onSubmit={onSubmit}>
+      <div className="form__grid form__grid--two">
+        <label className="field">
+          <span>Matricula <span className="asterisco">*</span></span>
+          <input name="matricula" value={form.matricula} onChange={onChange} required placeholder="12345" />
+        </label>
+        <label className="field">
+          <span>Nome <span className="asterisco">*</span></span>
+          <input name="nome" value={form.nome} onChange={onChange} required placeholder="Fulano de Tal" />
+        </label>
+        <label className="field">
+          <span>Cargo <span className="asterisco">*</span></span>
+          <input name="cargo" value={form.cargo} onChange={onChange} required placeholder="Operador" />
+        </label>
+        <label className="field">
+          <span>Data <span className="asterisco">*</span></span>
+          <input type="date" name="data" value={form.data} onChange={onChange} required />
+        </label>
+        <label className="field">
+          <span>Dias Perdidos</span>
+          <input type="number" min="0" name="diasPerdidos" value={form.diasPerdidos} onChange={onChange} placeholder="0" />
+        </label>
+        <label className="field">
+          <span>Dias Debitados</span>
+          <input type="number" min="0" name="diasDebitados" value={form.diasDebitados} onChange={onChange} placeholder="0" />
+        </label>
+        <label className="field">
+          <span>Tipo</span>
+          <input name="tipo" value={form.tipo} onChange={onChange} placeholder="Queda" />
+        </label>
+        <label className="field">
+          <span>Agente</span>
+          <input name="agente" value={form.agente} onChange={onChange} placeholder="Equipamento" />
+        </label>
+        <label className="field">
+          <span>CID</span>
+          <input name="cid" value={form.cid} onChange={onChange} placeholder="S93" />
+        </label>
+        <label className="field">
+          <span>Lesao</span>
+          <input name="lesao" value={form.lesao} onChange={onChange} placeholder="Entorse" />
+        </label>
+        <label className="field">
+          <span>Parte Lesionada</span>
+          <input name="parteLesionada" value={form.parteLesionada} onChange={onChange} placeholder="Tornozelo" />
+        </label>
+        <label className="field">
+          <span>Setor</span>
+          <input name="setor" value={form.setor} onChange={onChange} placeholder="Producao" />
+        </label>
+        <label className="field">
+          <span>Local</span>
+          <input name="local" value={form.local} onChange={onChange} placeholder="Linha 1" />
+        </label>
+        <label className="field">
+          <span>CAT</span>
+          <input name="cat" value={form.cat} onChange={onChange} placeholder="000000" />
+        </label>
+      </div>
+      {error ? <p className="feedback feedback--error">{error}</p> : null}
+      <div className="form__actions">
+        <button type="submit" className="button button--primary" disabled={isSaving}>
+          {isSaving ? 'Salvando...' : editingAcidente ? 'Salvar alteracoes' : 'Registrar acidente'}
+        </button>
+        {editingAcidente ? (
+          <button type="button" className="button button--ghost" onClick={onCancel} disabled={isSaving}>
+            Cancelar edicao
+          </button>
+        ) : null}
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/Acidentes/AcidentesTable.jsx
+++ b/frontend/src/components/Acidentes/AcidentesTable.jsx
@@ -1,0 +1,88 @@
+const formatDate = (value) => {
+  if (!value) {
+    return '-'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return new Intl.DateTimeFormat('pt-BR').format(date)
+}
+
+const formatNumber = (value) => {
+  if (value === null || value === undefined) {
+    return '-'
+  }
+  const numeric = Number(value)
+  if (Number.isNaN(numeric)) {
+    return '-'
+  }
+  return numeric
+}
+
+export function AcidentesTable({ acidentes, onEdit, editingId, isSaving }) {
+  if (!acidentes.length) {
+    return <p className="feedback">Nenhum acidente registrado.</p>
+  }
+
+  return (
+    <div className="table-wrapper">
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Matricula</th>
+            <th>Cargo</th>
+            <th>Data</th>
+            <th>Dias perdidos</th>
+            <th>Dias debitados</th>
+            <th>Tipo</th>
+            <th>Agente</th>
+            <th>Setor</th>
+            <th>Local</th>
+            <th>CAT</th>
+            <th>Acao</th>
+          </tr>
+        </thead>
+        <tbody>
+          {acidentes.map((acidente) => {
+            const isEditing = editingId === acidente.id
+            return (
+              <tr key={acidente.id}>
+                <td>
+                  <strong>{acidente.nome}</strong>
+                  {acidente.parteLesionada ? (
+                    <div className="data-table__muted">Parte lesionada: {acidente.parteLesionada}</div>
+                  ) : null}
+                  {acidente.lesao ? (
+                    <div className="data-table__muted">Lesao: {acidente.lesao}</div>
+                  ) : null}
+                </td>
+                <td>{acidente.matricula || '-'}</td>
+                <td>{acidente.cargo || '-'}</td>
+                <td>{formatDate(acidente.data)}</td>
+                <td>{formatNumber(acidente.diasPerdidos)}</td>
+                <td>{formatNumber(acidente.diasDebitados)}</td>
+                <td>{acidente.tipo || '-'}</td>
+                <td>{acidente.agente || '-'}</td>
+                <td>{acidente.setor || '-'}</td>
+                <td>{acidente.local || '-'}</td>
+                <td>{acidente.cat || '-'}</td>
+                <td>
+                  <button
+                    type="button"
+                    className="button button--ghost"
+                    onClick={() => onEdit(acidente)}
+                    disabled={isSaving}
+                  >
+                    {isEditing && isSaving ? 'Salvando...' : 'Editar'}
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/config/AcidentesConfig.js
+++ b/frontend/src/config/AcidentesConfig.js
@@ -1,0 +1,24 @@
+// Configuracoes e estados padrao relacionados a acidentes
+export const ACIDENTES_FORM_DEFAULT = {
+  matricula: '',
+  nome: '',
+  cargo: '',
+  data: '',
+  diasPerdidos: '',
+  diasDebitados: '',
+  tipo: '',
+  agente: '',
+  cid: '',
+  lesao: '',
+  parteLesionada: '',
+  setor: '',
+  local: '',
+  cat: '',
+}
+
+export const ACIDENTES_FILTER_DEFAULT = {
+  termo: '',
+  tipo: 'todos',
+  setor: 'todos',
+  agente: 'todos',
+}

--- a/frontend/src/pages/Acidentes.jsx
+++ b/frontend/src/pages/Acidentes.jsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { PageHeader } from '../components/PageHeader.jsx'
+import { AlertIcon } from '../components/icons.jsx'
+import { AcidentesForm } from '../components/Acidentes/AcidentesForm.jsx'
+import { AcidentesFilters } from '../components/Acidentes/AcidentesFilters.jsx'
+import { AcidentesTable } from '../components/Acidentes/AcidentesTable.jsx'
+import { api } from '../services/api.js'
+import { useAuth } from '../context/AuthContext.jsx'
+import { ACIDENTES_FORM_DEFAULT, ACIDENTES_FILTER_DEFAULT } from '../config/AcidentesConfig.js'
+import {
+  resolveUsuarioNome,
+  validateAcidenteForm,
+  createAcidentePayload,
+  updateAcidentePayload,
+  filterAcidentes,
+  extractAgentes,
+  extractSetores,
+  extractTipos,
+} from '../rules/AcidentesRules.js'
+
+const toInputDate = (value) => {
+  if (!value) {
+    return ''
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function AcidentesPage() {
+  const { user } = useAuth()
+  const [form, setForm] = useState(() => ({ ...ACIDENTES_FORM_DEFAULT }))
+  const [filters, setFilters] = useState(() => ({ ...ACIDENTES_FILTER_DEFAULT }))
+  const [acidentes, setAcidentes] = useState([])
+  const [editingAcidente, setEditingAcidente] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [listError, setListError] = useState(null)
+  const [formError, setFormError] = useState(null)
+
+  const loadAcidentes = useCallback(async () => {
+    setIsLoading(true)
+    setListError(null)
+    try {
+      const response = await api.acidentes.list()
+      setAcidentes(response ?? [])
+    } catch (err) {
+      setListError(err.message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadAcidentes()
+  }, [loadAcidentes])
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleFilterChange = (event) => {
+    const { name, value } = event.target
+    setFilters((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleFilterSubmit = (event) => {
+    event.preventDefault()
+  }
+
+  const handleFilterClear = () => {
+    setFilters({ ...ACIDENTES_FILTER_DEFAULT })
+  }
+
+  const resetForm = () => {
+    setForm({ ...ACIDENTES_FORM_DEFAULT })
+    setEditingAcidente(null)
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setIsSaving(true)
+    setFormError(null)
+
+    const validationError = validateAcidenteForm(form)
+    if (validationError) {
+      setFormError(validationError)
+      setIsSaving(false)
+      return
+    }
+
+    try {
+      const usuario = resolveUsuarioNome(user)
+
+      if (editingAcidente) {
+        await api.acidentes.update(editingAcidente.id, updateAcidentePayload(form, usuario))
+      } else {
+        await api.acidentes.create(createAcidentePayload(form, usuario))
+      }
+
+      resetForm()
+      await loadAcidentes()
+    } catch (err) {
+      setFormError(err.message)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const startEdit = (acidente) => {
+    setEditingAcidente(acidente)
+    setForm({
+      matricula: acidente.matricula || '',
+      nome: acidente.nome || '',
+      cargo: acidente.cargo || '',
+      data: toInputDate(acidente.data),
+      diasPerdidos: acidente.diasPerdidos !== null && acidente.diasPerdidos !== undefined ? String(acidente.diasPerdidos) : '',
+      diasDebitados:
+        acidente.diasDebitados !== null && acidente.diasDebitados !== undefined ? String(acidente.diasDebitados) : '',
+      tipo: acidente.tipo || '',
+      agente: acidente.agente || '',
+      cid: acidente.cid || '',
+      lesao: acidente.lesao || '',
+      parteLesionada: acidente.parteLesionada || '',
+      setor: acidente.setor || '',
+      local: acidente.local || '',
+      cat: acidente.cat || '',
+    })
+  }
+
+  const cancelEdit = () => {
+    resetForm()
+  }
+
+  const acidentesFiltrados = useMemo(
+    () => filterAcidentes(acidentes, filters),
+    [acidentes, filters],
+  )
+
+  const tipos = useMemo(() => extractTipos(acidentes), [acidentes])
+  const setores = useMemo(() => extractSetores(acidentes), [acidentes])
+  const agentes = useMemo(() => extractAgentes(acidentes), [acidentes])
+
+  return (
+    <div className="stack">
+      <PageHeader
+        icon={<AlertIcon size={28} />}
+        title="Acidentes"
+        subtitle="Registre acidentes de trabalho, filtre e acompanhe os indicadores."
+      />
+
+      <AcidentesForm
+        form={form}
+        onChange={handleFormChange}
+        onSubmit={handleSubmit}
+        isSaving={isSaving}
+        editingAcidente={editingAcidente}
+        onCancel={cancelEdit}
+        error={formError}
+      />
+
+      <AcidentesFilters
+        filters={filters}
+        tipos={tipos}
+        setores={setores}
+        agentes={agentes}
+        onChange={handleFilterChange}
+        onSubmit={handleFilterSubmit}
+        onClear={handleFilterClear}
+      />
+
+      <section className="card">
+        <header className="card__header">
+          <h2>Acidentes registrados</h2>
+          <button type="button" className="button button--ghost" onClick={loadAcidentes} disabled={isLoading}>
+            Atualizar
+          </button>
+        </header>
+        {listError ? <p className="feedback feedback--error">{listError}</p> : null}
+        {isLoading ? <p className="feedback">Carregando...</p> : null}
+        {!isLoading ? (
+          <AcidentesTable
+            acidentes={acidentesFiltrados}
+            onEdit={startEdit}
+            editingId={editingAcidente?.id ?? null}
+            isSaving={isSaving}
+          />
+        ) : null}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/rules/AcidentesRules.js
+++ b/frontend/src/rules/AcidentesRules.js
@@ -1,0 +1,141 @@
+// Utilitarios de validacao, normalizacao e filtros para acidentes
+
+const numberOrNull = (value) => {
+  if (value === undefined || value === null) {
+    return null
+  }
+  const trimmed = String(value).trim()
+  if (!trimmed) {
+    return null
+  }
+  const parsed = Number(trimmed)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export function resolveUsuarioNome(user) {
+  return user?.name || user?.username || user?.email || 'sistema'
+}
+
+export function validateAcidenteForm(form) {
+  if (!form.nome.trim()) {
+    return 'Informe o nome do colaborador.'
+  }
+  if (!form.matricula.trim()) {
+    return 'Informe a matricula.'
+  }
+  if (!form.cargo.trim()) {
+    return 'Informe o cargo.'
+  }
+  if (!form.data) {
+    return 'Selecione a data do acidente.'
+  }
+
+  const diasPerdidos = numberOrNull(form.diasPerdidos)
+  if (diasPerdidos !== null && diasPerdidos < 0) {
+    return 'Dias perdidos nao pode ser negativo.'
+  }
+
+  const diasDebitados = numberOrNull(form.diasDebitados)
+  if (diasDebitados !== null && diasDebitados < 0) {
+    return 'Dias debitados nao pode ser negativo.'
+  }
+
+  return null
+}
+
+export function createAcidentePayload(form, usuarioCadastro) {
+  return {
+    matricula: form.matricula.trim(),
+    nome: form.nome.trim(),
+    cargo: form.cargo.trim(),
+    data: form.data || null,
+    diasPerdidos: numberOrNull(form.diasPerdidos),
+    diasDebitados: numberOrNull(form.diasDebitados),
+    tipo: form.tipo.trim(),
+    agente: form.agente.trim(),
+    cid: form.cid.trim(),
+    lesao: form.lesao.trim(),
+    parteLesionada: form.parteLesionada.trim(),
+    setor: form.setor.trim(),
+    local: form.local.trim(),
+    cat: form.cat.trim(),
+    usuarioCadastro,
+  }
+}
+
+export function updateAcidentePayload(form, usuarioResponsavel) {
+  return {
+    matricula: form.matricula.trim(),
+    nome: form.nome.trim(),
+    cargo: form.cargo.trim(),
+    data: form.data || null,
+    diasPerdidos: numberOrNull(form.diasPerdidos),
+    diasDebitados: numberOrNull(form.diasDebitados),
+    tipo: form.tipo.trim(),
+    agente: form.agente.trim(),
+    cid: form.cid.trim(),
+    lesao: form.lesao.trim(),
+    parteLesionada: form.parteLesionada.trim(),
+    setor: form.setor.trim(),
+    local: form.local.trim(),
+    cat: form.cat.trim(),
+    usuarioResponsavel,
+  }
+}
+
+export function filterAcidentes(acidentes, filters) {
+  const termo = filters.termo.trim().toLowerCase()
+
+  return acidentes.filter((acidente) => {
+    if (filters.tipo !== 'todos' && (acidente.tipo || '').toLowerCase() !== filters.tipo.toLowerCase()) {
+      return false
+    }
+
+    if (filters.setor !== 'todos' && (acidente.setor || '').toLowerCase() !== filters.setor.toLowerCase()) {
+      return false
+    }
+
+    if (filters.agente !== 'todos' && (acidente.agente || '').toLowerCase() !== filters.agente.toLowerCase()) {
+      return false
+    }
+
+    if (!termo) {
+      return true
+    }
+
+    const alvo = [
+      acidente.nome,
+      acidente.matricula,
+      acidente.cargo,
+      acidente.tipo,
+      acidente.agente,
+      acidente.cid,
+      acidente.lesao,
+      acidente.parteLesionada,
+      acidente.setor,
+      acidente.local,
+      acidente.cat,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+
+    return alvo.includes(termo)
+  })
+}
+
+const buildSortedUnique = (items, accessor) => {
+  const values = new Set()
+  items.forEach((item) => {
+    const value = accessor(item)
+    if (!value) {
+      return
+    }
+    values.add(value.trim())
+  })
+  return Array.from(values).sort((a, b) => a.localeCompare(b))
+}
+
+export const extractTipos = (acidentes) => buildSortedUnique(acidentes, (item) => item.tipo)
+export const extractSetores = (acidentes) => buildSortedUnique(acidentes, (item) => item.setor)
+export const extractAgentes = (acidentes) => buildSortedUnique(acidentes, (item) => item.agente)

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -66,6 +66,11 @@ export const api = {
     update: (id, payload) => request(`/api/materiais/${id}`, { method: 'PUT', body: payload }),
     priceHistory: (id) => request(`/api/materiais/${id}/historico-precos`),
   },
+  acidentes: {
+    list: () => request('/api/acidentes'),
+    create: (payload) => request('/api/acidentes', { method: 'POST', body: payload }),
+    update: (id, payload) => request(`/api/acidentes/${id}`, { method: 'PUT', body: payload }),
+  },
   entradas: {
     list: () => request('/api/entradas'),
     create: (payload) => request('/api/entradas', { method: 'POST', body: payload }),


### PR DESCRIPTION
## Summary
- add a dedicated accidents page with form, filters, and table components following the existing layout
- provide configuration defaults and business rules for validating and preparing accidents data
- extend the API client and routing to expose the new accidents endpoints and screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d948a9da78832294197615cc287155