### PR TITLE
Require mandatory accident form fields

### DIFF
--- a/frontend/src/components/Acidentes/AcidentesForm.jsx
+++ b/frontend/src/components/Acidentes/AcidentesForm.jsx
@@ -58,40 +58,56 @@ export function AcidentesForm({
           <input type="date" name="data" value={form.data} onChange={onChange} required />
         </label>
         <label className="field">
-          <span>Dias Perdidos</span>
-          <input type="number" min="0" name="diasPerdidos" value={form.diasPerdidos} onChange={onChange} placeholder="0" />
+          <span>Dias Perdidos <span className="asterisco">*</span></span>
+          <input
+            type="number"
+            min="0"
+            name="diasPerdidos"
+            value={form.diasPerdidos}
+            onChange={onChange}
+            placeholder="0"
+            required
+          />
         </label>
         <label className="field">
-          <span>Dias Debitados</span>
-          <input type="number" min="0" name="diasDebitados" value={form.diasDebitados} onChange={onChange} placeholder="0" />
+          <span>Dias Debitados <span className="asterisco">*</span></span>
+          <input
+            type="number"
+            min="0"
+            name="diasDebitados"
+            value={form.diasDebitados}
+            onChange={onChange}
+            placeholder="0"
+            required
+          />
         </label>
         <label className="field">
-          <span>Tipo</span>
-          <input name="tipo" value={form.tipo} onChange={onChange} placeholder="Queda" />
+          <span>Tipo <span className="asterisco">*</span></span>
+          <input name="tipo" value={form.tipo} onChange={onChange} placeholder="Queda" required />
         </label>
         <label className="field">
-          <span>Agente</span>
-          <input name="agente" value={form.agente} onChange={onChange} placeholder="Equipamento" />
+          <span>Agente <span className="asterisco">*</span></span>
+          <input name="agente" value={form.agente} onChange={onChange} placeholder="Equipamento" required />
         </label>
         <label className="field">
           <span>CID</span>
           <input name="cid" value={form.cid} onChange={onChange} placeholder="S93" />
         </label>
         <label className="field">
-          <span>Lesao</span>
-          <input name="lesao" value={form.lesao} onChange={onChange} placeholder="Entorse" />
+          <span>Lesao <span className="asterisco">*</span></span>
+          <input name="lesao" value={form.lesao} onChange={onChange} placeholder="Entorse" required />
         </label>
         <label className="field">
-          <span>Parte Lesionada</span>
-          <input name="parteLesionada" value={form.parteLesionada} onChange={onChange} placeholder="Tornozelo" />
+          <span>Parte Lesionada <span className="asterisco">*</span></span>
+          <input name="parteLesionada" value={form.parteLesionada} onChange={onChange} placeholder="Tornozelo" required />
         </label>
         <label className="field">
-          <span>Setor</span>
-          <input name="setor" value={form.setor} readOnly placeholder="Producao" />
+          <span>Setor <span className="asterisco">*</span></span>
+          <input name="setor" value={form.setor} readOnly placeholder="Producao" required />
         </label>
         <label className="field">
-          <span>Local</span>
-          <input name="local" value={form.local} readOnly placeholder="Linha 1" />
+          <span>Local <span className="asterisco">*</span></span>
+          <input name="local" value={form.local} readOnly placeholder="Linha 1" required />
         </label>
         <label className="field">
           <span>CAT</span>

--- a/frontend/src/pages/Acidentes.jsx
+++ b/frontend/src/pages/Acidentes.jsx
@@ -138,15 +138,15 @@ export function AcidentesPage() {
 
   const handleSubmit = async (event) => {
     event.preventDefault()
-    setIsSaving(true)
     setFormError(null)
 
     const validationError = validateAcidenteForm(form)
     if (validationError) {
       setFormError(validationError)
-      setIsSaving(false)
       return
     }
+
+    setIsSaving(true)
 
     try {
       const usuario = resolveUsuarioNome(user)

--- a/frontend/src/rules/AcidentesRules.js
+++ b/frontend/src/rules/AcidentesRules.js
@@ -29,13 +29,47 @@ export function validateAcidenteForm(form) {
   if (!form.data) {
     return 'Selecione a data do acidente.'
   }
+  if (!form.tipo.trim()) {
+    return 'Informe o tipo do acidente.'
+  }
+  if (!form.agente.trim()) {
+    return 'Informe o agente do acidente.'
+  }
+  if (!form.lesao.trim()) {
+    return 'Informe a lesao.'
+  }
+  if (!form.parteLesionada.trim()) {
+    return 'Informe a parte lesionada.'
+  }
+  if (!form.setor.trim()) {
+    return 'Informe o setor.'
+  }
+  if (!form.local.trim()) {
+    return 'Informe o local.'
+  }
+
+  const hasDiasPerdidos = String(form.diasPerdidos ?? '').trim() !== ''
+  if (!hasDiasPerdidos) {
+    return 'Informe os dias perdidos.'
+  }
 
   const diasPerdidos = numberOrNull(form.diasPerdidos)
+  if (diasPerdidos === null) {
+    return 'Dias perdidos deve ser um numero valido.'
+  }
   if (diasPerdidos !== null && diasPerdidos < 0) {
     return 'Dias perdidos nao pode ser negativo.'
   }
 
+  const hasDiasDebitados = String(form.diasDebitados ?? '').trim() !== ''
+  if (!hasDiasDebitados) {
+    return 'Informe os dias debitados.'
+  }
+
   const diasDebitados = numberOrNull(form.diasDebitados)
+  if (diasDebitados === null) {
+    return 'Dias debitados deve ser um numero valido.'
+  }
   if (diasDebitados !== null && diasDebitados < 0) {
     return 'Dias debitados nao pode ser negativo.'
   }


### PR DESCRIPTION
## Summary
- enforce validation of accident form fields for type, agent, injury details, location, and day counts
- mark the corresponding accident form inputs as required to align the UI with the validation rules
- trigger the saving state only after validation passes so API calls are blocked when the form is incomplete

## Testing
- npm run frontend:lint *(fails: existing lint error in DashboardPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d95d382d148322b3d4dc22da471520