### PR TITLE
fix(rpc-catalog): corrigir escopo owner em rpc_catalog_list

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,14 +10,18 @@
 - Permissoes efetivas no banco agora expandem dependencias de pagina para atender a RLS dos catalogos.
 - Resolucao de owner efetivo passou a priorizar dependentes em `app_users_dependentes` para corrigir catalogos owner-scoped.
 - Catalogos owner-scoped passaram a isolar cache por `authUserId` e Pessoas voltou a usar `rpc_catalog_list` nas referencias.
+- Cache de catalogos owner-scoped foi removido no service; controladores de Saidas, Entradas, Cadastro Base e Acidentes limpam selects locais ao trocar de usuario.
+- Diagnostico SQL confirmou que o vazamento real estava em `public.rpc_catalog_list(text)`, nao no cache do frontend.
+- Migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` criada para impedir fallback global em catalogos owner-scoped.
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260305_expand_permission_dependencies.sql` no projeto Supabase.
-- Validar em producao o carregamento de centros de estoque/servico/custo para dependentes em Entradas, Saidas e cadastros que usam SelectBox owner-scoped.
-- Validar especificamente a tela Pessoas com dependente para confirmar que "Centro de servico" nao cai no fallback com dados fora do escopo.
-- Validar que nao existe reaproveitamento de cache entre usuarios diferentes no mesmo navegador.
+- Aplicar a migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` no projeto Supabase.
+- Validar por SQL com `request.jwt.claim.sub` de owner e dependente que `rpc_catalog_list('centros_servico')` e `rpc_catalog_list('centros_estoque')` nao retornam dados de outro `account_owner_id`.
+- Validar em producao o carregamento de centros de estoque/servico/custo para dependentes em Entradas, Saidas, Pessoas e cadastros que usam SelectBox owner-scoped.
 - Revisar o limite global de emails do Supabase Auth (`Auth -> Rate limits -> Rate limit for sending emails`).
 
 ## Observacoes
 - `git status` no sandbox exige `safe.directory` por causa do ownership do workspace.
 - Existem alteracoes locais previas em `src/pages/Configuracoes.jsx`, `src/config/permissions.js`, `docs/Configuracoes.txt` e `docs/PermissoesToggles.txt` que continuam sendo usadas.
+- O item `TESTE` foi reproduzido por SQL em `rpc_catalog_list('centros_estoque')` e `rpc_catalog_list('centros_servico')` com sessao simulada de dependente.

--- a/docs/Acidentes.txt
+++ b/docs/Acidentes.txt
@@ -19,7 +19,7 @@ Arquitetura (modular)
 ---------------------
 - Hooks principais:
   - `useAcidentes`: carrega a lista de acidentes, controla `isLoading`, `error` e expÃµe `reload()`.
-  - `useAcidenteForm`: controla estado do formulario, validacao, submit, edicao/cancelamento.
+  - `useAcidenteForm`: controla estado do formulario, validacao, submit, edicao/cancelamento e recarrega `centrosServicoOptions` quando muda o usuario/owner logado.
   - `useAcidenteFiltro`: guarda `filters` e aplica `filterAcidentes` gerando a lista filtrada.
   - `usePessoas`, `useAgentes`, `useLocais`, `usePartes`: carregam catÃ¡logos auxiliares de forma isolada, cada um com seu loading/erro.
 - Contexto opcional:

--- a/docs/CadastroBase.txt
+++ b/docs/CadastroBase.txt
@@ -14,6 +14,7 @@ Arquitetura
 - Hook `useCadastroBaseController`:
   - Centraliza estado de tabela selecionada, formulario, filtros, lista e historico.
   - Carrega dependencias (centros de custo/servico) para selects obrigatorios.
+  - Ao trocar de usuario, limpa dependencias locais e recarrega os catalogos owner-scoped.
   - Integra com logs via `useErrorLogger('cadastro-base')`.
 - Servicos:
   - `basicRegistrationService` concentra CRUD e historico via `dataClient`.

--- a/docs/Entradas.txt
+++ b/docs/Entradas.txt
@@ -23,6 +23,9 @@ Arquitetura
     - Busca/listagem de materiais e centros de estoque/custo.
 - Erros:
   - `useErrorLogger('entradas')` registra falhas de carga, submit, filtros, historico e erros de busca de materiais.
+- Troca de usuario:
+  - `useEntradasController` limpa materiais, centros e status locais quando o `userScopeKey` muda.
+  - O objetivo e evitar reaproveitamento de selects owner-scoped apos logout/login no mesmo navegador.
 
 Cadastro
 --------

--- a/docs/Pessoas.txt
+++ b/docs/Pessoas.txt
@@ -161,7 +161,7 @@ Atualizacao 2026-02 (Seguranca)
 - Cache de catalogos usa fallback por auth user id quando falha resolver owner, evitando reaproveitar dados de outro tenant.
 
 Atualizacao 2026-03 (Seguranca/UX)
-- Catalogos de pessoas (centros/setores/cargos) usam cache curto no frontend e filtro de tenant via `rpc_catalog_list`.
+- Catalogos de pessoas (centros/setores/cargos) usam filtro de tenant via `rpc_catalog_list`.
 - Carregamento de referencias ocorre uma vez por refresh para reduzir pisca no select.
 - Falha em resolver owner para catalogo retorna lista vazia (previne vazamento).
 - RPCs de resumo (`rpc_pessoas_resumo` e `rpc_pessoas_count_centro`) passaram a filtrar por tenant.
@@ -172,4 +172,9 @@ Atualizacao 2026-03 (Seguranca/UX)
 - `resolveEffectiveAppUser` agora prioriza `app_users_dependentes` antes do espelho em `app_users`, para dependente herdar o owner correto nos catalogos scoped.
 - `usePessoasController` nao deriva "Centro de servico" da lista de pessoas quando o usuario logado e dependente e as referencias scoped vierem vazias.
 - As referencias da tela (`centros_servico`, `setores`, `cargos`) voltaram a usar `rpc_catalog_list`, deixando o filtro de tenant no banco em vez de depender do owner resolvido no frontend.
-- O cache de catalogos passou a incluir o `authUserId` na chave para evitar reaproveitamento entre usuarios diferentes no mesmo navegador.
+- Catalogos owner-scoped deixaram de usar cache compartilhado no service; cada troca de usuario recarrega as referencias da tela.
+
+Atualizacao 2026-03 (Banco/RPC)
+- Diagnostico SQL com `request.jwt.claim.sub` confirmou vazamento cross-tenant em `public.rpc_catalog_list(text)` para dependente.
+- A migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` endurece o branch owner-scoped e remove o fallback global para usuario nao-master.
+- O teste de referencia da tela passou a ser a comparacao entre `rpc_catalog_list('centros_servico')` e a query direta filtrada por `current_account_owner_id()`.

--- a/docs/Saidas.txt
+++ b/docs/Saidas.txt
@@ -40,7 +40,8 @@ Cadastro
   - Bloqueia registro quando saldo do material <= 0 ou quando a quantidade informada supera o saldo disponivel.
   - Erros aparecem em area de feedback.
   - Dependentes usam o owner efetivo resolvido por `effectiveUserService`; isso evita lista vazia de centro de estoque quando existe espelho do dependente em `app_users`.
-  - A lista de centros owner-scoped usa `rpc_catalog_list`, com cache isolado por usuario autenticado.
+  - A lista de centros owner-scoped usa `rpc_catalog_list`, sem reaproveitar cache entre usuarios.
+  - Ao trocar de usuario, a tela zera as listas locais de centros e recarrega os selects antes de exibir os dados.
 
 Filtros, auto-complete e listagem
 ---------------------------------
@@ -224,3 +225,9 @@ Ajuda contextual
 ----------------
 - Botao "Ajuda" no cabecalho abre modal com passos e notas desta pagina.
 - Conteudo em src/help/helpSaidas.json; midias em /public/help/saidas/*.
+
+Atualizacao 2026-03 (Banco/RPC)
+-------------------------------
+- Diagnostico SQL com sessao simulada de dependente confirmou vazamento cross-tenant em `public.rpc_catalog_list('centros_estoque')`.
+- A migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` passa a exigir `account_owner_id` para tabelas owner-scoped quando o usuario nao e master.
+- O item `TESTE` era retornado indevidamente por `rpc_catalog_list`; a query direta em `public.centros_estoque` filtrada por `current_account_owner_id()` mostrou que o dado base do tenant estava correto.

--- a/src/hooks/useAcidenteForm.js
+++ b/src/hooks/useAcidenteForm.js
@@ -42,6 +42,11 @@ export function useAcidenteForm({
   onError,
 }) {
   const { user } = useAuth()
+  const userScopeKey = useMemo(() => {
+    const authId = user?.id ?? user?.user?.id ?? ''
+    const ownerId = user?.metadata?.app_user_id ?? user?.metadata?.dependent_of ?? ''
+    return `${authId}|${ownerId}`
+  }, [user?.id, user?.user?.id, user?.metadata?.app_user_id, user?.metadata?.dependent_of])
 
   const [form, setForm] = useState(() => ({ ...ACIDENTES_FORM_DEFAULT }))
   const [editingAcidente, setEditingAcidente] = useState(null)
@@ -895,6 +900,8 @@ export function useAcidenteForm({
 
   useEffect(() => {
     let cancelado = false
+    setCentrosServicoOptions([])
+    setCentrosServicoMap(new Map())
     const carregarCentros = async () => {
       try {
         const data = await listCentrosServico()
@@ -930,7 +937,7 @@ export function useAcidenteForm({
     return () => {
       cancelado = true
     }
-  }, [normalizeLookupKey])
+  }, [normalizeLookupKey, userScopeKey])
 
   useEffect(() => {
     // HHT não é mais preenchido no formulário; taxas são calculadas no dashboard usando hht_mensal.

--- a/src/hooks/useCadastroBaseController.js
+++ b/src/hooks/useCadastroBaseController.js
@@ -56,6 +56,11 @@ const resolveTableConfig = (key) => TABLES.find((item) => item.key === key) || T
 export function useCadastroBaseController() {
   const { reportError } = useErrorLogger('cadastro-base')
   const { user } = useAuth()
+  const userScopeKey = useMemo(() => {
+    const authId = user?.id ?? user?.user?.id ?? ''
+    const ownerId = user?.metadata?.app_user_id ?? user?.metadata?.dependent_of ?? ''
+    return `${authId}|${ownerId}`
+  }, [user?.id, user?.user?.id, user?.metadata?.app_user_id, user?.metadata?.dependent_of])
 
   const [tableKey, setTableKey] = useState(TABLES[0].key)
   const [form, setForm] = useState(buildDefaultForm)
@@ -139,6 +144,25 @@ export function useCadastroBaseController() {
     setForm(buildDefaultForm())
     setEditingItem(null)
   }, [loadList, tableKey])
+
+  useEffect(() => {
+    setItems([])
+    setCentrosCustoOptions([])
+    setCentrosServicoOptions([])
+    setHistoryModal({
+      open: false,
+      isLoading: false,
+      error: null,
+      item: null,
+      registros: [],
+    })
+    setFilters({ ...DEFAULT_FILTERS })
+    setForm(buildDefaultForm())
+    setEditingItem(null)
+    loadDependencies()
+    loadList({ ...DEFAULT_FILTERS })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userScopeKey])
 
   const dependencyStatus = useMemo(() => {
     const deps = tableConfig.dependsOn || []

--- a/src/hooks/useEntradasController.js
+++ b/src/hooks/useEntradasController.js
@@ -54,6 +54,11 @@ const CANCEL_INITIAL = {
 export function useEntradasController() {
   const { user } = useAuth()
   const { reportError } = useErrorLogger('entradas')
+  const userScopeKey = useMemo(() => {
+    const authId = user?.id ?? user?.user?.id ?? ''
+    const ownerId = user?.metadata?.app_user_id ?? user?.metadata?.dependent_of ?? ''
+    return `${authId}|${ownerId}`
+  }, [user?.id, user?.user?.id, user?.metadata?.app_user_id, user?.metadata?.dependent_of])
   const [materiais, setMateriais] = useState([])
   const [entradas, setEntradas] = useState([])
   const [centrosCusto, setCentrosCusto] = useState([])
@@ -130,9 +135,23 @@ export function useEntradasController() {
   )
 
   useEffect(() => {
-    load(initialEntradaFilters, { resetPage: true, refreshCatalogs: true })
+    setMateriais([])
+    setEntradas([])
+    setCentrosCusto([])
+    setStatusOptions([])
+    setEditingEntrada(null)
+    setForm(initialEntradaForm)
+    setFilters(initialEntradaFilters)
+    setCurrentPage(1)
+    setMaterialSearchValue('')
+    setMaterialSuggestions([])
+    setMaterialDropdownOpen(false)
+    setMaterialSearchError(null)
+    load(initialEntradaFilters, { resetPage: true, refreshCatalogs: true }).catch((err) =>
+      reportError(err, { area: 'entradas_scope_change', userScopeKey }),
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [userScopeKey])
 
   const handleChange = (event) => {
     const { name, value } = event.target

--- a/src/hooks/useSaidasController.js
+++ b/src/hooks/useSaidasController.js
@@ -68,6 +68,11 @@ const TROCA_PROMPT_INITIAL = {
 export function useSaidasController() {
   const { user } = useAuth()
   const { reportError } = useErrorLogger('saidas')
+  const userScopeKey = useMemo(() => {
+    const authId = user?.id ?? user?.user?.id ?? ''
+    const ownerId = user?.metadata?.app_user_id ?? user?.metadata?.dependent_of ?? ''
+    return `${authId}|${ownerId}`
+  }, [user?.id, user?.user?.id, user?.metadata?.app_user_id, user?.metadata?.dependent_of])
 
   const [pessoas, setPessoas] = useState([])
   const [materiais, setMateriais] = useState([])
@@ -173,11 +178,6 @@ export function useSaidasController() {
     [filters, centrosEstoqueOptions.length, centrosCustoOptions.length, centrosServicoOptions.length, reportError],
   )
 
-  useEffect(() => {
-    load(initialSaidaFilters, { resetPage: true })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   const dedupeMateriais = useCallback((lista = []) => {
     const mapa = new Map()
     ;(Array.isArray(lista) ? lista : []).forEach((item) => {
@@ -237,6 +237,25 @@ export function useSaidasController() {
   const closeTrocaPrompt = useCallback(() => {
     setTrocaPrompt(TROCA_PROMPT_INITIAL)
   }, [])
+
+  useEffect(() => {
+    setPessoas([])
+    setMateriais([])
+    setSaidas([])
+    setCentrosEstoqueOptions([])
+    setCentrosCustoOptions([])
+    setCentrosServicoOptions([])
+    setStatusOptions([])
+    setFilters(initialSaidaFilters)
+    setEditingSaida(null)
+    setCurrentPage(1)
+    materialSaldoCacheRef.current = new Map()
+    resetFormState()
+    load(initialSaidaFilters, { resetPage: true }).catch((err) => {
+      reportError(err, { area: 'saidas_scope_change', userScopeKey })
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userScopeKey])
 
   const confirmTroca = useCallback(async () => {
     if (!trocaPrompt.open || !trocaPrompt.payload) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -894,8 +894,8 @@ async function resolvePessoasOwnerScope() {
 }
 
 async function loadCatalogList({ table, nameColumn = 'nome', ownerScoped = true, errorMessage }) {
+  const scope = await resolveCatalogScope()
   if (!ownerScoped) {
-    const scope = await resolveCatalogScope()
     const cacheKey = buildCatalogCacheKey({
       table,
       nameColumn,
@@ -917,25 +917,11 @@ async function loadCatalogList({ table, nameColumn = 'nome', ownerScoped = true,
     return normalized
   }
 
-  const scope = await resolveCatalogScope()
-  const cacheKey = buildCatalogCacheKey({
-    table,
-    nameColumn,
-    ownerScoped,
-    ownerId: scope.ownerId,
-    isMaster: scope.isMaster,
-    authUserId: scope.authUserId,
-  })
-  const cached = readCatalogCache(cacheKey)
-  if (cached) {
-    return cached
-  }
   const data = await execute(
     supabase.rpc('rpc_catalog_list', { p_table: table }),
     errorMessage
   )
   const normalized = normalizeDomainOptions(data ?? [])
-  writeCatalogCache(cacheKey, normalized)
   return normalized
 }
 
@@ -943,17 +929,21 @@ async function loadCatalogScopedList({ table, nameColumn = 'nome', ownerScoped =
   ensureSupabase()
   const scope = await resolveCatalogScope()
   const isMaster = scope.isMaster
-  const cacheKey = buildCatalogCacheKey({
-    table,
-    nameColumn,
-    ownerScoped,
-    ownerId: scope.ownerId,
-    isMaster,
-    authUserId: scope.authUserId,
-  })
-  const cached = readCatalogCache(cacheKey)
-  if (cached) {
-    return cached
+  const cacheKey = ownerScoped
+    ? null
+    : buildCatalogCacheKey({
+        table,
+        nameColumn,
+        ownerScoped,
+        ownerId: scope.ownerId,
+        isMaster,
+        authUserId: scope.authUserId,
+      })
+  if (cacheKey) {
+    const cached = readCatalogCache(cacheKey)
+    if (cached) {
+      return cached
+    }
   }
   let query = supabase.from(table).select(`id, ${nameColumn}`)
 
@@ -975,7 +965,9 @@ async function loadCatalogScopedList({ table, nameColumn = 'nome', ownerScoped =
       return { id: item?.id ?? null, nome }
     })
     .filter(Boolean)
-  writeCatalogCache(cacheKey, normalized)
+  if (cacheKey) {
+    writeCatalogCache(cacheKey, normalized)
+  }
   return normalized
 }
 

--- a/supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql
+++ b/supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql
@@ -1,0 +1,77 @@
+-- Corrige o escopo owner-scoped do rpc_catalog_list para evitar fallback global.
+
+create or replace function public.rpc_catalog_list(p_table text)
+returns table (id uuid, nome text)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_table text := lower(trim(p_table));
+  v_caller_id uuid := auth.uid();
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := coalesce(public.is_master(), false);
+  v_col text := 'nome';
+  v_owner_table boolean := v_table = any (array[
+    'centros_servico',
+    'setores',
+    'cargos',
+    'centros_custo',
+    'centros_estoque',
+    'fabricantes'
+  ]);
+begin
+  if v_table not in (
+    'centros_servico',
+    'setores',
+    'cargos',
+    'centros_custo',
+    'centros_estoque',
+    'fabricantes',
+    'tipo_execucao'
+  ) then
+    raise exception 'Tabela invalida.';
+  end if;
+
+  if v_caller_id is null then
+    raise exception 'Nao autenticado.';
+  end if;
+
+  if v_table = 'centros_estoque' then
+    v_col := 'almox';
+  end if;
+
+  if v_owner_table then
+    if v_is_master then
+      return query execute format(
+        'select id, %I as nome from public.%I order by %I',
+        v_col,
+        v_table,
+        v_col
+      );
+    end if;
+
+    if v_owner is null then
+      raise exception 'Owner nao identificado para usuario %.', v_caller_id;
+    end if;
+
+    return query execute format(
+      'select id, %I as nome from public.%I where account_owner_id = $1 order by %I',
+      v_col,
+      v_table,
+      v_col
+    ) using v_owner;
+  end if;
+
+  return query execute format(
+    'select id, %I as nome from public.%I order by %I',
+    v_col,
+    v_table,
+    v_col
+  );
+end;
+$$;
+
+revoke all on function public.rpc_catalog_list(text) from public;
+grant execute on function public.rpc_catalog_list(text) to authenticated;


### PR DESCRIPTION
- O que foi feito:
  - Corrigida a funcao public.rpc_catalog_list para impedir fallback global em tabelas owner-scoped
  - Endurecido o fluxo para centros_servico, centros_estoque, centros_custo, setores, cargos e fabricantes
  - Mantido retorno global apenas para tabelas realmente globais
  - Validado o comportamento com sessao simulada de dependente

- Arquivos:
  - supabase/migrations/20260306_fix_rpc_catalog_list_owner_scope.sql
  - docs/Pessoas.txt
  - docs/Saidas.txt
  - TASKS.md

- Mapeamento:
  - Banco/RPC: catalogos owner-scoped passam a respeitar account_owner_id do tenant
  - Pessoas: select de centro de servico deixa de vazar registros de outros tenants
  - Saidas/Entradas/Cadastro Base: select de centro de estoque deixa de vazar registros de outros tenants

- Como validar:
  - Simular sessao com request.jwt.claim.sub de dependente
  - Rodar public.rpc_catalog_list('centros_servico')
  - Rodar public.rpc_catalog_list('centros_estoque')
  - Confirmar que registros de outro account_owner_id nao aparecem

- Multi-tenant:
  - Corrige vazamento cross-tenant em catalogos owner-scoped
  - Mantem acesso global apenas para tabelas globais e master real

- Docs:
  - docs/Pessoas.txt atualizado
  - docs/Saidas.txt atualizado
  - TASKS.md atualizado