### PR TITLE
fix(auditoria): usar ator real da sessao no cadastrado por de depende…

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -13,12 +13,15 @@
 - Cache de catalogos owner-scoped foi removido no service; controladores de Saidas, Entradas, Cadastro Base e Acidentes limpam selects locais ao trocar de usuario.
 - Diagnostico SQL confirmou que o vazamento real estava em `public.rpc_catalog_list(text)`, nao no cache do frontend.
 - Migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` criada para impedir fallback global em catalogos owner-scoped.
+- `resolveUsuarioId()` foi corrigido para devolver o ator real da sessao; dependentes deixam de gravar o owner em campos de auditoria/"cadastrado por".
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260305_expand_permission_dependencies.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` no projeto Supabase.
 - Validar por SQL com `request.jwt.claim.sub` de owner e dependente que `rpc_catalog_list('centros_servico')` e `rpc_catalog_list('centros_estoque')` nao retornam dados de outro `account_owner_id`.
 - Validar em producao o carregamento de centros de estoque/servico/custo para dependentes em Entradas, Saidas, Pessoas e cadastros que usam SelectBox owner-scoped.
+- Validar no app que "Cadastrado por"/"Registrado por" mostra o dependente nas telas Pessoas, Materiais, Saidas e Cadastro Base.
+- Validar no app que Acidentes continua exibindo o dependente em "Registrado por" e que HHT mensal permanece consistente no historico/listagem.
 - Revisar o limite global de emails do Supabase Auth (`Auth -> Rate limits -> Rate limit for sending emails`).
 
 ## Observacoes

--- a/docs/Acidentes.txt
+++ b/docs/Acidentes.txt
@@ -124,6 +124,11 @@ Atualizacao 2026-02 (API)
 - Cadastro passou a chamar `/api/acidentes` (Vercel) em vez de RPC direta.
 - Pipeline aplica rate limit e idempotencia no create.
 - Arquivos: src/services/api.js, api/index.js, api/_shared/operations.js.
+
+Atualizacao 2026-03 (Auditoria)
+-------------------------------
+- O create/update de acidentes ja usa `resolveUsuarioResponsavel()`, que prioriza o perfil do dependente e preserva o nome do ator real em `registradoPor`/`atualizadoPor`.
+- O cancelamento passou a se beneficiar da correcao em `resolveUsuarioId()`, evitando gravar o owner do tenant em `updated_by_username` quando a sessao e de dependente.
 - `createAcidentePayload` e `updateAcidentePayload`:
   - Montam o payload no formato esperado pela API/BD.
   - Mantem consistencia entre listas (`agentes`, `tipos`, `lesoes`, `partesLesionadas`) e campos unicos legados (`agente`, `tipo`, `lesao`, `parteLesionada`).

--- a/docs/CadastroBase.txt
+++ b/docs/CadastroBase.txt
@@ -154,3 +154,8 @@ Servicos e integracoes externas
 Ajuda contextual
 ----------------
 - Nao ha ajuda contextual dedicada ainda.
+
+Atualizacao 2026-03 (Auditoria)
+-------------------------------
+- O cadastro base deixou de gravar o owner do tenant como `created_by_user_id`/`updated_by_user_id` quando um dependente salva um registro.
+- `resolveUsuarioId()` agora devolve o ator real da sessao; imports continuam usando o owner via `resolveImportsOwnerId()`.

--- a/docs/Entradas.txt
+++ b/docs/Entradas.txt
@@ -127,6 +127,11 @@ Atualizacao 2026-02 (API)
 - Cadastro passou a chamar `/api/entradas` (Vercel) em vez de RPC direta.
 - Pipeline aplica rate limit e idempotencia no create.
 - Arquivos: src/services/api.js, api/index.js, api/_shared/operations.js.
+
+Atualizacao 2026-03 (Auditoria)
+-------------------------------
+- `resolveUsuarioId()` deixou de devolver o owner do tenant quando a sessao e de dependente.
+- O campo de responsavel/registro das entradas passa a refletir o ator real da sessao.
 - Importacao em massa valida tamanho do arquivo pelo plano (limit_import_mb, padrao 2 MB) e bloqueia acima do limite.
 - Importacao em massa aplica rate limit (1 requisicao a cada 60s) e limite diario por plano (limit_import_daily).
 

--- a/docs/HhtMensal.txt
+++ b/docs/HhtMensal.txt
@@ -131,3 +131,8 @@ Ajuda contextual
 ----------------
 - HelpButton no header abre conteudo "hhtMensal".
 - Conteudo vem de src/help/helpHhtMensal.json e midias em public/help/hht-mensal.
+
+Atualizacao 2026-03 (Auditoria)
+-------------------------------
+- O fluxo de HHT mensal nao usa o helper que estava devolvendo o owner do tenant em cadastros do frontend.
+- Create/update continuam dependendo do contexto autenticado do RPC (`rpc_hht_mensal_create_full`/`rpc_hht_mensal_update_full`), sem troca adicional para owner no frontend.

--- a/docs/Materiais.txt
+++ b/docs/Materiais.txt
@@ -92,3 +92,7 @@ Atualizacao 2026-02 (API)
 - Cadastro passou a chamar `/api/materiais` (Vercel) em vez de RPC direta.
 - Pipeline aplica rate limit e idempotencia no create.
 - Arquivos: src/services/api.js, api/index.js, api/_shared/operations.js.
+
+Atualizacao 2026-03 (Auditoria)
+- Cadastros e edicoes feitos por dependentes deixaram de gravar o owner do tenant em `usuarioCadastro`/`usuarioAtualizacao`.
+- O helper `resolveUsuarioId()` agora retorna o ator real da sessao para manter "Cadastrado por" alinhado com quem executou a acao.

--- a/docs/Pessoas.txt
+++ b/docs/Pessoas.txt
@@ -178,3 +178,8 @@ Atualizacao 2026-03 (Banco/RPC)
 - Diagnostico SQL com `request.jwt.claim.sub` confirmou vazamento cross-tenant em `public.rpc_catalog_list(text)` para dependente.
 - A migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` endurece o branch owner-scoped e remove o fallback global para usuario nao-master.
 - O teste de referencia da tela passou a ser a comparacao entre `rpc_catalog_list('centros_servico')` e a query direta filtrada por `current_account_owner_id()`.
+
+Atualizacao 2026-03 (Auditoria)
+- `resolveUsuarioId()` passou a devolver o ator real da sessao (`auth_user_id` do dependente) em vez do owner do tenant.
+- Com isso, `usuarioCadastro`/`usuarioEdicao` e o campo "Cadastrado por" passam a mostrar quem executou a acao, nao o titular.
+- Uploads/importacoes continuam usando o owner do tenant via `resolveImportsOwnerId()`.

--- a/docs/Saidas.txt
+++ b/docs/Saidas.txt
@@ -231,3 +231,8 @@ Atualizacao 2026-03 (Banco/RPC)
 - Diagnostico SQL com sessao simulada de dependente confirmou vazamento cross-tenant em `public.rpc_catalog_list('centros_estoque')`.
 - A migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` passa a exigir `account_owner_id` para tabelas owner-scoped quando o usuario nao e master.
 - O item `TESTE` era retornado indevidamente por `rpc_catalog_list`; a query direta em `public.centros_estoque` filtrada por `current_account_owner_id()` mostrou que o dado base do tenant estava correto.
+
+Atualizacao 2026-03 (Auditoria)
+-------------------------------
+- `resolveUsuarioId()` deixou de devolver o owner do tenant quando a sessao e de dependente.
+- Campos de auditoria/registro da tela passam a preservar o ator real da sessao em vez do titular.

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2216,7 +2216,7 @@ async function resolveUsuarioId() {
     if (effective?.active === false) {
       throw new Error('Usuario inativo. Procure um administrador.')
     }
-    return effective?.appUserId || user.id
+    return effective?.dependentProfile?.auth_user_id || effective?.profile?.id || user.id
   } catch (error) {
     reportClientError('Falha ao resolver usuario efetivo.', error, { userId: user.id })
     throw error
@@ -2231,8 +2231,35 @@ async function resolveUsuarioIdOrThrow() {
   return usuarioId
 }
 
+async function resolveOwnerUsuarioId() {
+  ensureSupabase()
+  const { data } = await supabase.auth.getSession()
+  const user = data?.session?.user
+  if (!user?.id) {
+    return null
+  }
+  try {
+    const effective = await resolveEffectiveAppUser(user.id)
+    if (effective?.active === false) {
+      throw new Error('Usuario inativo. Procure um administrador.')
+    }
+    return effective?.appUserId || effective?.profile?.parent_user_id || effective?.profile?.id || user.id
+  } catch (error) {
+    reportClientError('Falha ao resolver owner do usuario efetivo.', error, { userId: user.id })
+    throw error
+  }
+}
+
+async function resolveOwnerUsuarioIdOrThrow() {
+  const ownerId = await resolveOwnerUsuarioId()
+  if (!ownerId) {
+    throw new Error('Sessao invalida, owner nao identificado.')
+  }
+  return ownerId
+}
+
 async function resolveImportsOwnerId() {
-  const ownerId = await resolveUsuarioIdOrThrow()
+  const ownerId = await resolveOwnerUsuarioIdOrThrow()
   const normalized = normalizeUuid(ownerId)
   if (!normalized) {
     throw new Error('Owner invalido para importacao.')


### PR DESCRIPTION
…ntes

- O que foi feito:
  - Corrigido resolveUsuarioId para devolver o ator real da sessao
  - Dependentes passam a usar auth_user_id em vez do owner do tenant nos campos de auditoria
  - Criado resolveOwnerUsuarioId para manter imports e uploads no escopo do tenant
  - Atualizadas docs das telas afetadas e TASKS

- Arquivos:
  - src/services/api.js
  - docs/Pessoas.txt
  - docs/Materiais.txt
  - docs/CadastroBase.txt
  - docs/Entradas.txt
  - docs/Saidas.txt
  - TASKS.md

- Mapeamento:
  - API compartilhada: resolveUsuarioId deixa de retornar owner para dependentes
  - Imports: resolveImportsOwnerId continua usando owner do tenant
  - Pessoas: usuarioCadastro/usuarioEdicao passa a refletir o dependente
  - Materiais: usuarioCadastro/usuarioAtualizacao passa a refletir o dependente
  - Cadastro Base: created_by_user_id/updated_by_user_id passa a refletir o dependente
  - Entradas/Saidas: campos de responsavel/registro passam a refletir o ator real

- Como validar:
  - Logar com dependente
  - Criar registros em Pessoas, Materiais, Cadastro Base, Entradas e Saidas
  - Confirmar que Cadastrado por/Registrado por mostra o dependente
  - Confirmar que importacoes continuam em imports/<owner_id>/...

- Multi-tenant:
  - Mantem o owner do tenant para imports/storage
  - Corrige apenas a identificacao do ator nos campos de auditoria
  - Sem ampliar escopo de leitura/escrita entre tenants

- Docs:
  - docs/Pessoas.txt atualizado
  - docs/Materiais.txt atualizado
  - docs/CadastroBase.txt atualizado
  - docs/Entradas.txt atualizado
  - docs/Saidas.txt atualizado
  - TASKS.md atualizado