### PR TITLE
fix(reset-password): traduz erro de senha repetida e adiciona toggle …

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,7 @@
 # Tasks
 
 ## Concluido
+- Tela de reset de senha passou a traduzir o erro de senha repetida para portugues e ganhou exibicao/ocultacao por icone de olho nos campos de senha.
 - Removida a reautenticacao obrigatoria nas rotas protegidas do backend/front.
 - Fluxo de reset de senha voltou a usar Supabase direto com `token_hash` na tela de reset.
 - Configuracoes agora bloqueiam auto-rebaixamento, auto-desativacao e remocao de `rbac.manage`.

--- a/docs/ResetPassword.txt
+++ b/docs/ResetPassword.txt
@@ -48,6 +48,18 @@ Atualizacao 2026-03
   - Antes: falha de fetch no HIBP podia travar o reset com "Failed to fetch".
   - Depois: falhas de rede retornam "nao vazada" e o fluxo segue.
 
+Atualizacao 2026-04
+-------------------
+- A tela passou a permitir mostrar/ocultar os campos "Nova senha" e "Confirmar nova senha".
+- A mensagem retornada pelo Supabase para senha repetida passou a ser traduzida para portugues no fluxo de reset.
+- Arquivos alterados:
+  - `src/pages/ResetPasswordPage.jsx`
+  - `src/styles/ResetPasswordPage.css`
+  - `src/services/authService.js`
+- Antes/Depois:
+  - Antes: os campos sempre mascaravam a senha digitada e o erro "New password should be different from the old password." aparecia em ingles.
+  - Depois: o usuario pode alternar a visibilidade das senhas pelo botao com icone de olho e o erro aparece como "A nova senha deve ser diferente da senha anterior.".
+
 ===========================================
 Mapa de Codigo (funcoes, hooks e constantes)
 ===========================================
@@ -57,7 +69,7 @@ Funcoes principais
 - ResetPasswordPage
   - Tipo: componente de pagina React
   - Caminho: src/pages/ResetPasswordPage.jsx
-  - Responsavel por: layout do formulario e exibicao de feedbacks.
+  - Responsavel por: layout do formulario, exibicao de feedbacks e alternancia visual dos campos de senha.
 - useResetPassword
   - Tipo: hook
   - Caminho: src/hooks/useResetPassword.js
@@ -82,7 +94,11 @@ Servicos e integracoes externas
 - authService (restoreResetSession, updatePassword)
   - Tipo: servico
   - Caminho: src/services/authService.js
-  - Responsavel por: validar link e atualizar senha no Supabase.
+  - Responsavel por: validar link, atualizar senha no Supabase e traduzir mensagens conhecidas do provider no reset.
+- ResetPasswordPage.css
+  - Tipo: estilo da pagina
+  - Caminho: src/styles/ResetPasswordPage.css
+  - Responsavel por: posicionar o botao de mostrar/ocultar senha e manter o layout do formulario.
 - passwordPolicyService (validatePasswordOrThrow)
   - Tipo: servico
   - Caminho: src/services/passwordPolicyService.js

--- a/src/pages/ResetPasswordPage.jsx
+++ b/src/pages/ResetPasswordPage.jsx
@@ -1,3 +1,6 @@
+import { useState } from 'react'
+import Eye from 'lucide-react/dist/esm/icons/eye.js'
+import EyeOff from 'lucide-react/dist/esm/icons/eye-off.js'
 import { useResetPassword } from '../hooks/useResetPassword.js'
 import { securityConfig } from '../config/security.js'
 import { CaptchaGuard } from '../components/CaptchaGuard.jsx'
@@ -6,6 +9,10 @@ import '../styles/ResetPasswordPage.css'
 const logoSrc = '/logo_segtrab.png'
 
 export function ResetPasswordPage() {
+  const [visibleFields, setVisibleFields] = useState({
+    newPassword: false,
+    confirmPassword: false,
+  })
   const {
     form,
     status,
@@ -19,6 +26,13 @@ export function ResetPasswordPage() {
     handleCaptchaToken,
     handleCancel,
   } = useResetPassword()
+
+  const toggleFieldVisibility = (fieldName) => {
+    setVisibleFields((prev) => ({
+      ...prev,
+      [fieldName]: !prev[fieldName],
+    }))
+  }
 
   return (
     <div className="reset-page">
@@ -51,31 +65,55 @@ export function ResetPasswordPage() {
         <form className="reset-form" onSubmit={handleSubmit}>
           <label className="reset-field">
             <span>Nova senha</span>
-            <input
-              type="password"
-              name="newPassword"
-              value={form.newPassword}
-              onChange={handleChange}
-              minLength={securityConfig.password.minLength}
-              autoComplete="new-password"
-              placeholder="Digite a nova senha"
-              disabled={isFormDisabled}
-              required
-            />
+            <div className="reset-field__input-wrap">
+              <input
+                type={visibleFields.newPassword ? 'text' : 'password'}
+                name="newPassword"
+                value={form.newPassword}
+                onChange={handleChange}
+                minLength={securityConfig.password.minLength}
+                autoComplete="new-password"
+                placeholder="Digite a nova senha"
+                disabled={isFormDisabled}
+                required
+              />
+              <button
+                type="button"
+                className="reset-field__toggle"
+                onClick={() => toggleFieldVisibility('newPassword')}
+                aria-label={visibleFields.newPassword ? 'Ocultar nova senha' : 'Mostrar nova senha'}
+                aria-pressed={visibleFields.newPassword}
+                disabled={isFormDisabled}
+              >
+                {visibleFields.newPassword ? <EyeOff size={18} strokeWidth={1.8} /> : <Eye size={18} strokeWidth={1.8} />}
+              </button>
+            </div>
           </label>
 
           <label className="reset-field">
             <span>Confirmar nova senha</span>
-            <input
-              type="password"
-              name="confirmPassword"
-              value={form.confirmPassword}
-              onChange={handleChange}
-              autoComplete="new-password"
-              placeholder="Repita a nova senha"
-              disabled={isFormDisabled}
-              required
-            />
+            <div className="reset-field__input-wrap">
+              <input
+                type={visibleFields.confirmPassword ? 'text' : 'password'}
+                name="confirmPassword"
+                value={form.confirmPassword}
+                onChange={handleChange}
+                autoComplete="new-password"
+                placeholder="Repita a nova senha"
+                disabled={isFormDisabled}
+                required
+              />
+              <button
+                type="button"
+                className="reset-field__toggle"
+                onClick={() => toggleFieldVisibility('confirmPassword')}
+                aria-label={visibleFields.confirmPassword ? 'Ocultar confirmacao de senha' : 'Mostrar confirmacao de senha'}
+                aria-pressed={visibleFields.confirmPassword}
+                disabled={isFormDisabled}
+              >
+                {visibleFields.confirmPassword ? <EyeOff size={18} strokeWidth={1.8} /> : <Eye size={18} strokeWidth={1.8} />}
+              </button>
+            </div>
           </label>
 
           {status ? <p className={`feedback feedback--${status.type}`}>{status.message}</p> : null}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -3,6 +3,19 @@ import { logError } from './errorLogService.js'
 import { validatePasswordOrThrow } from './passwordPolicyService.js'
 import { request as httpRequest } from './httpClient.js'
 
+function translateAuthErrorMessage(message) {
+  const normalized = (message || '').trim()
+  if (!normalized) {
+    return 'Nao foi possivel concluir a operacao de autenticacao.'
+  }
+
+  if (normalized === 'New password should be different from the old password.') {
+    return 'A nova senha deve ser diferente da senha anterior.'
+  }
+
+  return normalized
+}
+
 function assertSupabase() {
   if (!isSupabaseConfigured() || !supabase) {
     throw new Error('Supabase nao configurado. Configure VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY.')
@@ -97,7 +110,7 @@ export async function updatePassword(newPassword) {
     data: { password_changed_at: new Date().toISOString() },
   })
   if (error) {
-    throw new Error(error.message)
+    throw new Error(translateAuthErrorMessage(error.message))
   }
   return true
 }

--- a/src/styles/ResetPasswordPage.css
+++ b/src/styles/ResetPasswordPage.css
@@ -125,13 +125,19 @@
   color: #0f172a;
 }
 
+.reset-field__input-wrap {
+  position: relative;
+}
+
 .reset-field input {
   padding: 0.9rem 1rem;
+  padding-right: 3.5rem;
   border-radius: 0.9rem;
   border: 1px solid rgba(148, 163, 184, 0.5);
   background: #ffffff;
   font-size: 0.98rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
 }
 
 .reset-field input:focus {
@@ -143,6 +149,38 @@
 .reset-field input:disabled {
   background: rgba(226, 232, 240, 0.5);
   cursor: not-allowed;
+}
+
+.reset-field__toggle {
+  position: absolute;
+  top: 50%;
+  right: 0.75rem;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: transparent;
+  color: rgba(71, 85, 105, 0.92);
+  cursor: pointer;
+  padding: 0;
+}
+
+.reset-field__toggle:hover:not(:disabled) {
+  color: var(--color-primary);
+}
+
+.reset-field__toggle:focus-visible {
+  outline: 2px solid rgba(22, 163, 74, 0.35);
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}
+
+.reset-field__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .reset-actions {


### PR DESCRIPTION
…de visibilidade

- O que foi feito:
  - traduzi a mensagem retornada pelo Supabase quando a nova senha coincide com a anterior
  - adicionei botao com icone de olho para mostrar/ocultar os campos de nova senha e confirmacao
  - ajustei o CSS da tela de reset para suportar o botao lateral sem quebrar o layout
  - atualizei a documentacao da tela e o TASKS.md

- Arquivos tocados:
  - src/services/authService.js
  - src/pages/ResetPasswordPage.jsx
  - src/styles/ResetPasswordPage.css
  - docs/ResetPassword.txt
  - TASKS.md

- Mapeamento por modulo/tela:
  - ResetPasswordPage: passou a controlar a visibilidade dos dois campos de senha
  - authService: passou a traduzir mensagem conhecida do provider no update de senha
  - ResetPasswordPage.css: adicionou wrapper e botao de toggle no input
  - docs/ResetPassword.txt: documentou comportamento antes/depois da tela
  - TASKS.md: registrou a entrega no estado atual do projeto

- Como validar:
  - npm run build
  - abrir a tela de reset por link de recuperacao
  - testar o toggle de visibilidade nos dois campos
  - tentar reutilizar a senha anterior e conferir a mensagem em portugues

- Impacto multi-tenant:
  - sem impacto em RLS, account_owner_id ou isolamento entre tenants

- Docs atualizadas:
  - docs/ResetPassword.txt atualizado