### PR TITLE
feat(aso): criar base de dominio e API para controle de ASO

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,8 @@
 # Tasks
 
 ## Concluido
+- Base do dominio de ASO foi criada com migration versionada (`aso_tipos_exame`, `aso_controle`, `aso_historico`), view (`aso_controle_view`) e RPCs de create/update/registrar exame.
+- API e services ganharam a base de integracao para ASO (listagem, tipos, cadastro, edicao, registro de exame e historico).
 - Tela de reset de senha passou a traduzir o erro de senha repetida para portugues e ganhou exibicao/ocultacao por icone de olho nos campos de senha.
 - Removida a reautenticacao obrigatoria nas rotas protegidas do backend/front.
 - Fluxo de reset de senha voltou a usar Supabase direto com `token_hash` na tela de reset.
@@ -17,6 +19,14 @@
 - `resolveUsuarioId()` foi corrigido para devolver o ator real da sessao; dependentes deixam de gravar o owner em campos de auditoria/"cadastrado por".
 
 ## Pendente
+- Implementar a tela de ASO (cadastro, cards, filtros, lista, detalhes, historico e modal "Registrar exame").
+- Implementar cadastro em massa de ASO via XLSX com template, validacoes, relatorio de erros e bloqueio de duplicidade.
+- Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
+- Validar no banco o comportamento de `proximo_vencimento`:
+  - admissional e periodico somam 1 ano a partir de `data_exame`
+  - demissional fica sem renovacao e sem alerta
+- Validar por SQL e no app a constraint de duplicidade por tenant em `aso_controle` (`account_owner_id + pessoa_id + tipo_exame_id`).
+- Atualizar a documentacao obrigatoria da feature (`docs/ASO.txt`) e o `README.md` se a mudanca impactar uso/configuracao.
 - Aplicar a migration `supabase/migrations/20260305_expand_permission_dependencies.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260308_fix_rpc_catalog_list_owner_scope.sql` no projeto Supabase.
 - Validar por SQL com `request.jwt.claim.sub` de owner e dependente que `rpc_catalog_list('centros_servico')` e `rpc_catalog_list('centros_estoque')` nao retornam dados de outro `account_owner_id`.

--- a/api/_shared/operations.js
+++ b/api/_shared/operations.js
@@ -576,6 +576,79 @@ function normalizePessoaHistorico(lista) {
     .filter(Boolean)
 }
 
+function mapAsoRecord(record) {
+  if (!record || typeof record !== 'object') {
+    return record
+  }
+  return {
+    ...record,
+    id: record.id ?? null,
+    pessoaId: record.pessoa_id ?? record.pessoaId ?? null,
+    funcionario: record.funcionario ?? record.nome ?? '',
+    nome: record.nome ?? record.funcionario ?? '',
+    matricula: record.matricula ?? '',
+    centroServicoId: record.centro_servico_id ?? record.centroServicoId ?? null,
+    centroServico: record.centro_servico ?? record.centroServico ?? '',
+    setorId: record.setor_id ?? record.setorId ?? null,
+    setor: record.setor ?? '',
+    cargoId: record.cargo_id ?? record.cargoId ?? null,
+    cargo: record.cargo ?? '',
+    tipoExameId: record.tipo_exame_id ?? record.tipoExameId ?? null,
+    tipoExameCodigo: record.tipo_exame_codigo ?? record.tipoExameCodigo ?? '',
+    tipoExame: record.tipo_exame ?? record.tipoExame ?? '',
+    dataExame: record.data_exame ?? record.dataExame ?? null,
+    proximoVencimento: record.proximo_vencimento ?? record.proximoVencimento ?? null,
+    diasParaVencer: record.dias_para_vencer ?? record.diasParaVencer ?? null,
+    statusVencimento: record.status_vencimento ?? record.statusVencimento ?? '',
+    observacao: record.observacao ?? '',
+    usuarioCadastro: record.usuario_cadastro ?? record.usuarioCadastro ?? null,
+    usuarioCadastroNome: record.usuario_cadastro_nome ?? record.usuarioCadastroNome ?? '',
+    usuarioEdicao: record.usuario_edicao ?? record.usuarioEdicao ?? null,
+    usuarioEdicaoNome: record.usuario_edicao_nome ?? record.usuarioEdicaoNome ?? '',
+    criadoEm: record.criado_em ?? record.criadoEm ?? null,
+    atualizadoEm: record.atualizado_em ?? record.atualizadoEm ?? null,
+    accountOwnerId: record.account_owner_id ?? record.accountOwnerId ?? null,
+  }
+}
+
+function normalizeAsoHistory(lista) {
+  if (!Array.isArray(lista)) {
+    return []
+  }
+  return lista
+    .map((registro) => {
+      if (!registro || typeof registro !== 'object') {
+        return null
+      }
+      return {
+        id: registro.id ?? randomId(),
+        asoId: registro.aso_id ?? registro.asoId ?? null,
+        pessoaId: registro.pessoa_id ?? registro.pessoaId ?? null,
+        acao: trim(registro.acao ?? ''),
+        criadoEm: registro.criado_em ?? registro.criadoEm ?? null,
+        observacao: registro.observacao ?? '',
+        usuarioResponsavelId:
+          registro.usuario_responsavel_id ?? registro.usuario_responsavel ?? registro.usuarioResponsavel ?? null,
+        usuarioResponsavel:
+          registro.usuario_responsavel_nome ??
+          registro.usuarioResponsavelNome ??
+          registro.usuario_responsavel ??
+          registro.usuarioResponsavel ??
+          'sistema',
+        dadosAntes: registro.dados_antes ?? recordToObject(registro.dadosAntes) ?? null,
+        dadosDepois: registro.dados_depois ?? recordToObject(registro.dadosDepois) ?? {},
+      }
+    })
+    .filter(Boolean)
+}
+
+function recordToObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  return value
+}
+
 async function ensureMatriculaDisponivel(matricula, ignoreId) {
   if (!matricula) {
     return
@@ -2026,6 +2099,205 @@ export const PessoasOperations = {
         'Falha ao obter hist?rico.'
       )) ?? []
     return normalizePessoaHistorico(registros)
+  },
+}
+
+export const AsoOperations = {
+  async list(params = {}, user = {}) {
+    const ownerId = user?.id ? await resolveOwnerId(user.id) : null
+    let query = supabaseAdmin.from('aso_controle_view').select('*').order('proximo_vencimento', { ascending: true })
+
+    if (ownerId) {
+      query = query.eq('account_owner_id', ownerId)
+    }
+
+    const termo = trim(params.termo ?? params.buscar ?? '')
+    if (termo) {
+      const like = `%${termo}%`
+      query = query.or(`funcionario.ilike.${like},nome.ilike.${like},matricula.ilike.${like}`)
+    }
+
+    const tipoExameId = trim(params.tipoExameId ?? params.tipo_exame_id ?? '')
+    if (tipoExameId) {
+      query = query.eq('tipo_exame_id', tipoExameId)
+    }
+
+    const status = trim(params.status ?? '')
+    if (status) {
+      query = query.eq('status_vencimento', status)
+    }
+
+    const centroServico = trim(params.centroServico ?? params.centro_servico ?? '')
+    if (centroServico) {
+      query = query.ilike('centro_servico', `%${centroServico}%`)
+    }
+
+    const setor = trim(params.setor ?? '')
+    if (setor) {
+      query = query.ilike('setor', `%${setor}%`)
+    }
+
+    const cargo = trim(params.cargo ?? '')
+    if (cargo) {
+      query = query.ilike('cargo', `%${cargo}%`)
+    }
+
+    const dataInicio = trim(params.dataInicio ?? params.data_inicial ?? '')
+    if (dataInicio) {
+      query = query.gte('data_exame', dataInicio)
+    }
+
+    const dataFim = trim(params.dataFim ?? params.data_final ?? '')
+    if (dataFim) {
+      query = query.lte('data_exame', dataFim)
+    }
+
+    const registros = await execute(query, 'Falha ao listar registros de ASO.')
+    return (registros ?? []).map(mapAsoRecord)
+  },
+
+  async types() {
+    const registros = await execute(
+      supabaseAdmin
+        .from('aso_tipos_exame')
+        .select('id, codigo, nome, gera_vencimento, anos_validade, ordem, ativo')
+        .eq('ativo', true)
+        .order('ordem', { ascending: true }),
+      'Falha ao listar tipos de exame.'
+    )
+    return registros ?? []
+  },
+
+  async create(payload, user, authToken) {
+    const params = {
+      p_pessoa_id: pickParam(payload, ['p_pessoa_id', 'pessoaId', 'pessoa_id']),
+      p_tipo_exame_id: pickParam(payload, ['p_tipo_exame_id', 'tipoExameId', 'tipo_exame_id']),
+      p_data_exame: pickParam(payload, ['p_data_exame', 'dataExame', 'data_exame']),
+      p_observacao: pickParam(payload, ['p_observacao', 'observacao']),
+      p_usuario_id: pickParam(payload, ['p_usuario_id'], user?.id ?? null),
+    }
+
+    if (!params.p_pessoa_id) {
+      throw createHttpError(400, 'Funcionario obrigatorio para cadastrar ASO.')
+    }
+    if (!params.p_tipo_exame_id) {
+      throw createHttpError(400, 'Tipo de exame obrigatorio.')
+    }
+    if (!params.p_data_exame) {
+      throw createHttpError(400, 'Data do exame obrigatoria.')
+    }
+
+    const client = buildUserClient(authToken)
+    const registro = await executeSingle(
+      client.rpc('rpc_aso_create_full', params),
+      'Falha ao criar ASO.'
+    )
+
+    return mapAsoRecord(registro)
+  },
+
+  async update(id, payload, user, authToken) {
+    if (!id) {
+      throw createHttpError(400, 'ASO invalido.')
+    }
+
+    const params = {
+      p_id: id,
+      p_tipo_exame_id: pickParam(payload, ['p_tipo_exame_id', 'tipoExameId', 'tipo_exame_id']),
+      p_data_exame: pickParam(payload, ['p_data_exame', 'dataExame', 'data_exame']),
+      p_observacao: pickParam(payload, ['p_observacao', 'observacao']),
+      p_usuario_id: pickParam(payload, ['p_usuario_id'], user?.id ?? null),
+      p_acao: 'edicao',
+    }
+
+    if (!params.p_tipo_exame_id) {
+      throw createHttpError(400, 'Tipo de exame obrigatorio.')
+    }
+    if (!params.p_data_exame) {
+      throw createHttpError(400, 'Data do exame obrigatoria.')
+    }
+
+    const client = buildUserClient(authToken)
+    const registro = await executeSingle(
+      client.rpc('rpc_aso_update_full', params),
+      'Falha ao atualizar ASO.'
+    )
+
+    return mapAsoRecord(registro)
+  },
+
+  async registerExam(id, payload, user, authToken) {
+    if (!id) {
+      throw createHttpError(400, 'ASO invalido.')
+    }
+
+    const params = {
+      p_id: id,
+      p_data_realizada: pickParam(payload, ['p_data_realizada', 'dataRealizada', 'data_realizada']),
+      p_observacao: pickParam(payload, ['p_observacao', 'observacao']),
+      p_usuario_id: pickParam(payload, ['p_usuario_id'], user?.id ?? null),
+    }
+
+    if (!params.p_data_realizada) {
+      throw createHttpError(400, 'Data realizada obrigatoria.')
+    }
+
+    const client = buildUserClient(authToken)
+    const registro = await executeSingle(
+      client.rpc('rpc_aso_register_exam', params),
+      'Falha ao registrar exame.'
+    )
+
+    return mapAsoRecord(registro)
+  },
+
+  async history(id) {
+    if (!id) {
+      throw createHttpError(400, 'ASO invalido.')
+    }
+
+    const registros = await execute(
+      supabaseAdmin
+        .from('aso_historico')
+        .select('id, aso_id, pessoa_id, acao, dados_antes, dados_depois, observacao, usuario_responsavel, criado_em')
+        .eq('aso_id', id)
+        .order('criado_em', { ascending: true }),
+      'Falha ao obter historico do ASO.'
+    )
+
+    const lista = registros ?? []
+    const usuariosIds = Array.from(
+      new Set(
+        lista
+          .map((item) => item?.usuario_responsavel)
+          .filter((value) => typeof value === 'string' && value.trim())
+      )
+    )
+
+    let usuariosMap = new Map()
+    if (usuariosIds.length > 0) {
+      const usuarios = await execute(
+        supabaseAdmin
+          .from('app_users')
+          .select('id, display_name, username, email')
+          .in('id', usuariosIds),
+        'Falha ao resolver usuarios do historico de ASO.'
+      )
+      usuariosMap = new Map(
+        (usuarios ?? []).map((item) => [
+          item.id,
+          trim(item.username) || trim(item.display_name) || trim(item.email) || item.id,
+        ])
+      )
+    }
+
+    const enriquecido = lista.map((item) => ({
+      ...item,
+      usuario_responsavel_id: item?.usuario_responsavel ?? null,
+      usuario_responsavel_nome: usuariosMap.get(item?.usuario_responsavel) || item?.usuario_responsavel || 'sistema',
+    }))
+
+    return normalizeAsoHistory(enriquecido)
   },
 }
 

--- a/api/index.js
+++ b/api/index.js
@@ -8,6 +8,7 @@ import {
 } from './_shared/http.js'
 import {
   PessoasOperations,
+  AsoOperations,
   MateriaisOperations,
   AcidentesOperations,
   EntradasOperations,
@@ -87,6 +88,45 @@ export default withAuth(async (req, res, user) => {
         })
       }
       return sendJson(res, 200, await PessoasOperations.history(id))
+    }
+
+    // ASO
+    if (path === '/api/aso/tipos' && method === 'GET') {
+      return sendJson(res, 200, await AsoOperations.types())
+    }
+    if (path === '/api/aso') {
+      if (method === 'GET') return sendJson(res, 200, await AsoOperations.list(query, user))
+      if (method === 'POST') {
+        const body = await readJson(req)
+        return sendJson(res, 201, await AsoOperations.create(body, user, req.authToken))
+      }
+    }
+    if (path.startsWith('/api/aso/register-exam/') && method === 'POST') {
+      const id = path.split('/')[4]
+      if (!id) {
+        throw createHttpError(400, 'ID do ASO nao informado para registrar exame.', {
+          code: 'VALIDATION_ERROR',
+        })
+      }
+      const body = await readJson(req)
+      return sendJson(res, 200, await AsoOperations.registerExam(id, body, user, req.authToken))
+    }
+    if (path.startsWith('/api/aso/history/') && method === 'GET') {
+      const id = path.split('/')[4]
+      if (!id) {
+        throw createHttpError(400, 'ID do ASO nao informado para historico.', {
+          code: 'VALIDATION_ERROR',
+        })
+      }
+      return sendJson(res, 200, await AsoOperations.history(id))
+    }
+    if (path.startsWith('/api/aso/') && method === 'PUT') {
+      const id = path.split('/')[3]
+      if (!id) {
+        throw createHttpError(400, 'ID do ASO nao informado.', { code: 'VALIDATION_ERROR' })
+      }
+      const body = await readJson(req)
+      return sendJson(res, 200, await AsoOperations.update(id, body, user, req.authToken))
     }
 
     // Materiais

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2512,6 +2512,72 @@ function mapPessoaRecord(record) {
   }
 }
 
+function mapAsoRecord(record) {
+  if (!record) {
+    return null
+  }
+  return {
+    id: record.id ?? null,
+    pessoaId: record.pessoa_id ?? record.pessoaId ?? null,
+    funcionario: resolveTextValue(record.funcionario ?? record.nome ?? ''),
+    nome: resolveTextValue(record.nome ?? record.funcionario ?? ''),
+    matricula: resolveTextValue(record.matricula ?? ''),
+    centroServicoId: record.centro_servico_id ?? record.centroServicoId ?? null,
+    centroServico: resolveTextValue(record.centro_servico ?? record.centroServico ?? ''),
+    setorId: record.setor_id ?? record.setorId ?? null,
+    setor: resolveTextValue(record.setor ?? ''),
+    cargoId: record.cargo_id ?? record.cargoId ?? null,
+    cargo: resolveTextValue(record.cargo ?? ''),
+    tipoExameId: record.tipo_exame_id ?? record.tipoExameId ?? null,
+    tipoExameCodigo: resolveTextValue(record.tipo_exame_codigo ?? record.tipoExameCodigo ?? ''),
+    tipoExame: resolveTextValue(record.tipo_exame ?? record.tipoExame ?? ''),
+    dataExame: record.data_exame ?? record.dataExame ?? null,
+    proximoVencimento: record.proximo_vencimento ?? record.proximoVencimento ?? null,
+    diasParaVencer: toNullableNumber(record.dias_para_vencer ?? record.diasParaVencer),
+    statusVencimento: resolveTextValue(record.status_vencimento ?? record.statusVencimento ?? ''),
+    observacao: resolveTextValue(record.observacao ?? ''),
+    usuarioCadastro: record.usuario_cadastro ?? record.usuarioCadastro ?? null,
+    usuarioCadastroNome: resolveTextValue(record.usuario_cadastro_nome ?? record.usuarioCadastroNome ?? ''),
+    usuarioEdicao: record.usuario_edicao ?? record.usuarioEdicao ?? null,
+    usuarioEdicaoNome: resolveTextValue(record.usuario_edicao_nome ?? record.usuarioEdicaoNome ?? ''),
+    criadoEm: record.criado_em ?? record.criadoEm ?? null,
+    atualizadoEm: record.atualizado_em ?? record.atualizadoEm ?? null,
+    accountOwnerId: record.account_owner_id ?? record.accountOwnerId ?? null,
+  }
+}
+
+function normalizeAsoHistory(registros = []) {
+  if (!Array.isArray(registros)) {
+    return []
+  }
+  return registros
+    .map((registro) => {
+      if (!registro || typeof registro !== 'object') {
+        return null
+      }
+      return {
+        id: registro.id ?? null,
+        asoId: registro.aso_id ?? registro.asoId ?? null,
+        pessoaId: registro.pessoa_id ?? registro.pessoaId ?? null,
+        acao: resolveTextValue(registro.acao ?? ''),
+        criadoEm: registro.criado_em ?? registro.criadoEm ?? null,
+        observacao: resolveTextValue(registro.observacao ?? ''),
+        usuarioResponsavelId:
+          registro.usuario_responsavel_id ?? registro.usuario_responsavel ?? registro.usuarioResponsavel ?? null,
+        usuarioResponsavel: resolveTextValue(
+          registro.usuario_responsavel_nome ??
+            registro.usuarioResponsavelNome ??
+            registro.usuario_responsavel ??
+            registro.usuarioResponsavel ??
+            'sistema'
+        ),
+        dadosAntes: registro.dados_antes ?? registro.dadosAntes ?? null,
+        dadosDepois: registro.dados_depois ?? registro.dadosDepois ?? {},
+      }
+    })
+    .filter(Boolean)
+}
+
 function mapEntradaRecord(record) {
   if (!record) {
     return null
@@ -4889,6 +4955,157 @@ export const api = {
         )
         throw err
       }
+    },
+  },
+  aso: {
+    async list(params = {}) {
+      let query = supabase.from('aso_controle_view').select('*').order('proximo_vencimento', { ascending: true })
+
+      const termo = trim(params.termo ?? params.buscar ?? '')
+      if (termo) {
+        const like = `%${termo}%`
+        query = query.or(`funcionario.ilike.${like},nome.ilike.${like},matricula.ilike.${like}`)
+      }
+
+      const tipoExameId = trim(params.tipoExameId ?? params.tipo_exame_id ?? '')
+      if (tipoExameId) {
+        query = query.eq('tipo_exame_id', tipoExameId)
+      }
+
+      const status = trim(params.status ?? '')
+      if (status) {
+        query = query.eq('status_vencimento', status)
+      }
+
+      const centroServico = trim(params.centroServico ?? params.centro_servico ?? '')
+      if (centroServico) {
+        query = query.ilike('centro_servico', `%${centroServico}%`)
+      }
+
+      const setor = trim(params.setor ?? '')
+      if (setor) {
+        query = query.ilike('setor', `%${setor}%`)
+      }
+
+      const cargo = trim(params.cargo ?? '')
+      if (cargo) {
+        query = query.ilike('cargo', `%${cargo}%`)
+      }
+
+      const dataInicio = trim(params.dataInicio ?? params.data_inicial ?? '')
+      if (dataInicio) {
+        query = query.gte('data_exame', dataInicio)
+      }
+
+      const dataFim = trim(params.dataFim ?? params.data_final ?? '')
+      if (dataFim) {
+        query = query.lte('data_exame', dataFim)
+      }
+
+      const registros = await execute(query, 'Falha ao listar ASOs.')
+      return (registros ?? []).map(mapAsoRecord)
+    },
+
+    async types() {
+      const registros = await execute(
+        supabase
+          .from('aso_tipos_exame')
+          .select('id, codigo, nome, gera_vencimento, anos_validade, ordem, ativo')
+          .eq('ativo', true)
+          .order('ordem', { ascending: true }),
+        'Falha ao listar tipos de exame.'
+      )
+      return registros ?? []
+    },
+
+    async create(payload) {
+      const headers = await buildAuthHeaders({ 'Content-Type': 'application/json' })
+      if (!headers.Authorization) {
+        throw new Error('Sessao expirada. Faça login novamente.')
+      }
+      const base = (import.meta.env.VITE_API_URL || '').trim().replace(/\/+$/, '')
+      const endpoint = `${base}/api/aso`
+      const registro = await httpRequest('POST', endpoint, { body: payload, headers })
+      return mapAsoRecord(registro)
+    },
+
+    async update(id, payload) {
+      if (!id) {
+        throw new Error('ID obrigatorio.')
+      }
+      const headers = await buildAuthHeaders({ 'Content-Type': 'application/json' })
+      if (!headers.Authorization) {
+        throw new Error('Sessao expirada. Faça login novamente.')
+      }
+      const base = (import.meta.env.VITE_API_URL || '').trim().replace(/\/+$/, '')
+      const endpoint = `${base}/api/aso/${id}`
+      const registro = await httpRequest('PUT', endpoint, { body: payload, headers })
+      return mapAsoRecord(registro)
+    },
+
+    async registerExam(id, payload) {
+      if (!id) {
+        throw new Error('ID obrigatorio.')
+      }
+      const headers = await buildAuthHeaders({ 'Content-Type': 'application/json' })
+      if (!headers.Authorization) {
+        throw new Error('Sessao expirada. Faça login novamente.')
+      }
+      const base = (import.meta.env.VITE_API_URL || '').trim().replace(/\/+$/, '')
+      const endpoint = `${base}/api/aso/register-exam/${id}`
+      const registro = await httpRequest('POST', endpoint, { body: payload, headers })
+      return mapAsoRecord(registro)
+    },
+
+    async history(id) {
+      if (!id) {
+        throw new Error('ID obrigatorio.')
+      }
+      const registros = await execute(
+        supabase
+          .from('aso_historico')
+          .select('id, aso_id, pessoa_id, acao, dados_antes, dados_depois, observacao, usuario_responsavel, criado_em')
+          .eq('aso_id', id)
+          .order('criado_em', { ascending: true }),
+        'Falha ao obter historico de ASO.'
+      )
+
+      const lista = registros ?? []
+      const usuariosIds = Array.from(
+        new Set(
+          lista
+            .map((item) => item?.usuario_responsavel)
+            .filter((value) => typeof value === 'string' && value.trim())
+        )
+      )
+
+      let usuariosMap = new Map()
+      if (usuariosIds.length > 0) {
+        const usuarios = await execute(
+          supabase
+            .from('app_users')
+            .select('id, display_name, username, email')
+            .in('id', usuariosIds),
+          'Falha ao resolver usuarios do historico de ASO.'
+        )
+        usuariosMap = new Map(
+          (usuarios ?? []).map((item) => [
+            item.id,
+            resolveTextValue(item.username) ||
+              resolveTextValue(item.display_name) ||
+              resolveTextValue(item.email) ||
+              item.id,
+          ])
+        )
+      }
+
+      const enriquecido = lista.map((item) => ({
+        ...item,
+        usuario_responsavel_id: item?.usuario_responsavel ?? null,
+        usuario_responsavel_nome: usuariosMap.get(item?.usuario_responsavel) || item?.usuario_responsavel || 'sistema',
+      }))
+
+      return normalizeAsoHistory(enriquecido)
     },
   },
   materiais: {

--- a/src/services/asoService.js
+++ b/src/services/asoService.js
@@ -1,0 +1,35 @@
+import { dataClient as api } from './dataClient.js'
+
+export const listAsos = (query = {}) =>
+  api?.aso?.list ? api.aso.list(query) : Promise.resolve([])
+
+export const listAsoTiposExame = () =>
+  api?.aso?.types ? api.aso.types() : Promise.resolve([])
+
+export const createAso = (payload) => {
+  if (!api?.aso?.create) {
+    return Promise.reject(new Error('Endpoint de cadastro de ASO nao configurado.'))
+  }
+  return api.aso.create(payload)
+}
+
+export const updateAso = (id, payload) => {
+  if (!api?.aso?.update) {
+    return Promise.reject(new Error('Endpoint de atualizacao de ASO nao configurado.'))
+  }
+  return api.aso.update(id, payload)
+}
+
+export const registerAsoExam = (id, payload) => {
+  if (!api?.aso?.registerExam) {
+    return Promise.reject(new Error('Endpoint de registro de exame nao configurado.'))
+  }
+  return api.aso.registerExam(id, payload)
+}
+
+export const getAsoHistory = (id) => {
+  if (!api?.aso?.history) {
+    return Promise.reject(new Error('Endpoint de historico de ASO nao configurado.'))
+  }
+  return api.aso.history(id)
+}

--- a/supabase/migrations/20260412_create_aso_control.sql
+++ b/supabase/migrations/20260412_create_aso_control.sql
@@ -1,0 +1,584 @@
+-- Cria o dominio de controle de ASO com catalogo fixo, historico e RPCs.
+
+create table if not exists public.aso_tipos_exame (
+  id uuid primary key default gen_random_uuid(),
+  codigo text not null unique,
+  nome text not null unique,
+  gera_vencimento boolean not null default true,
+  anos_validade smallint null,
+  ordem smallint not null default 0,
+  ativo boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz null
+);
+
+insert into public.aso_tipos_exame (
+  codigo,
+  nome,
+  gera_vencimento,
+  anos_validade,
+  ordem,
+  ativo
+)
+values
+  ('admissional', 'Admissional', true, 1, 1, true),
+  ('periodico', 'Periodico', true, 1, 2, true),
+  ('demissional', 'Demissional', false, null, 3, true)
+on conflict (codigo) do update
+set
+  nome = excluded.nome,
+  gera_vencimento = excluded.gera_vencimento,
+  anos_validade = excluded.anos_validade,
+  ordem = excluded.ordem,
+  ativo = excluded.ativo,
+  updated_at = now();
+
+create table if not exists public.aso_controle (
+  id uuid primary key default gen_random_uuid(),
+  pessoa_id uuid not null references public.pessoas(id) on delete cascade,
+  tipo_exame_id uuid not null references public.aso_tipos_exame(id),
+  data_exame date not null,
+  proximo_vencimento date null,
+  observacao text null,
+  usuario_cadastro uuid null references public.app_users(id),
+  usuario_edicao uuid null references public.app_users(id),
+  criado_em timestamptz not null default now(),
+  atualizado_em timestamptz null,
+  account_owner_id uuid not null default public.my_owner_id() references public.app_users(id),
+  constraint aso_controle_owner_pessoa_tipo_unique unique (account_owner_id, pessoa_id, tipo_exame_id)
+);
+
+create index if not exists aso_controle_owner_idx
+  on public.aso_controle (account_owner_id);
+
+create index if not exists aso_controle_pessoa_idx
+  on public.aso_controle (pessoa_id, tipo_exame_id);
+
+create index if not exists aso_controle_vencimento_idx
+  on public.aso_controle (proximo_vencimento);
+
+create table if not exists public.aso_historico (
+  id uuid primary key default gen_random_uuid(),
+  aso_id uuid not null references public.aso_controle(id) on delete cascade,
+  pessoa_id uuid not null references public.pessoas(id) on delete cascade,
+  acao text not null,
+  dados_antes jsonb null,
+  dados_depois jsonb not null default '{}'::jsonb,
+  observacao text null,
+  usuario_responsavel uuid null references public.app_users(id),
+  criado_em timestamptz not null default now(),
+  account_owner_id uuid not null default public.my_owner_id() references public.app_users(id),
+  constraint aso_historico_acao_check check (acao in ('cadastro', 'edicao', 'registro_exame'))
+);
+
+create index if not exists aso_historico_aso_idx
+  on public.aso_historico (aso_id, criado_em desc);
+
+create index if not exists aso_historico_pessoa_idx
+  on public.aso_historico (pessoa_id, criado_em desc);
+
+create or replace function public.apply_aso_proximo_vencimento()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_gera_vencimento boolean;
+  v_anos_validade smallint;
+begin
+  select
+    gera_vencimento,
+    coalesce(anos_validade, 1)
+  into
+    v_gera_vencimento,
+    v_anos_validade
+  from public.aso_tipos_exame
+  where id = new.tipo_exame_id
+    and ativo = true;
+
+  if not found then
+    raise exception 'tipo_exame_aso_not_found' using errcode = '23503';
+  end if;
+
+  if new.data_exame is null then
+    new.proximo_vencimento := null;
+  elsif coalesce(v_gera_vencimento, false) then
+    new.proximo_vencimento := (new.data_exame + make_interval(years => v_anos_validade))::date;
+  else
+    new.proximo_vencimento := null;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_aso_proximo_vencimento on public.aso_controle;
+create trigger trg_aso_proximo_vencimento
+before insert or update of tipo_exame_id, data_exame
+on public.aso_controle
+for each row
+execute function public.apply_aso_proximo_vencimento();
+
+create or replace view public.aso_controle_view as
+select
+  aso.id,
+  aso.pessoa_id,
+  pv.nome as funcionario,
+  pv.nome,
+  pv.matricula,
+  pv.centro_servico_id,
+  pv.centro_servico,
+  pv."centroServico",
+  pv.setor_id,
+  pv.setor,
+  pv.cargo_id,
+  pv.cargo,
+  aso.tipo_exame_id,
+  tipo.codigo as tipo_exame_codigo,
+  tipo.nome as tipo_exame,
+  aso.data_exame,
+  aso.proximo_vencimento,
+  case
+    when aso.proximo_vencimento is null then null
+    else (aso.proximo_vencimento - current_date)
+  end as dias_para_vencer,
+  case
+    when tipo.codigo = 'demissional' then 'demissional'
+    when aso.proximo_vencimento is null then 'sem_vencimento'
+    when aso.proximo_vencimento < current_date then 'vencido'
+    when aso.proximo_vencimento = current_date then 'vence_hoje'
+    when aso.proximo_vencimento <= (current_date + 15) then 'vence_15'
+    when aso.proximo_vencimento <= (current_date + 30) then 'vence_30'
+    when aso.proximo_vencimento <= (current_date + 60) then 'vence_60'
+    else 'em_dia'
+  end as status_vencimento,
+  aso.observacao,
+  aso.usuario_cadastro,
+  coalesce(uc.username, uc.display_name, uc.email, aso.usuario_cadastro::text) as usuario_cadastro_nome,
+  aso.usuario_edicao,
+  coalesce(ue.username, ue.display_name, ue.email, aso.usuario_edicao::text) as usuario_edicao_nome,
+  aso.criado_em,
+  aso.atualizado_em,
+  aso.account_owner_id
+from public.aso_controle aso
+join public.pessoas_view pv on pv.id = aso.pessoa_id
+join public.aso_tipos_exame tipo on tipo.id = aso.tipo_exame_id
+left join public.app_users uc on uc.id = aso.usuario_cadastro
+left join public.app_users ue on ue.id = aso.usuario_edicao;
+
+grant select on public.aso_controle_view to authenticated, anon, service_role;
+
+alter table if exists public.aso_tipos_exame enable row level security;
+alter table if exists public.aso_controle enable row level security;
+alter table if exists public.aso_historico enable row level security;
+
+drop policy if exists aso_tipos_exame_select_all on public.aso_tipos_exame;
+drop policy if exists aso_tipos_exame_block_insert on public.aso_tipos_exame;
+drop policy if exists aso_tipos_exame_block_update on public.aso_tipos_exame;
+drop policy if exists aso_tipos_exame_block_delete on public.aso_tipos_exame;
+
+create policy aso_tipos_exame_select_all
+  on public.aso_tipos_exame
+  for select
+  to anon, authenticated
+  using (true);
+
+create policy aso_tipos_exame_block_insert
+  on public.aso_tipos_exame
+  for insert
+  to authenticated
+  with check (false);
+
+create policy aso_tipos_exame_block_update
+  on public.aso_tipos_exame
+  for update
+  to authenticated
+  using (false)
+  with check (false);
+
+create policy aso_tipos_exame_block_delete
+  on public.aso_tipos_exame
+  for delete
+  to authenticated
+  using (false);
+
+drop policy if exists aso_controle_select_owner on public.aso_controle;
+drop policy if exists aso_controle_insert_owner on public.aso_controle;
+drop policy if exists aso_controle_update_owner on public.aso_controle;
+
+create policy aso_controle_select_owner
+  on public.aso_controle
+  for select
+  to authenticated
+  using (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.read'::text)
+      or public.has_permission('pessoas.write'::text)
+    )
+  );
+
+create policy aso_controle_insert_owner
+  on public.aso_controle
+  for insert
+  to authenticated
+  with check (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.write'::text)
+    )
+  );
+
+create policy aso_controle_update_owner
+  on public.aso_controle
+  for update
+  to authenticated
+  using (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.write'::text)
+    )
+  )
+  with check (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.write'::text)
+    )
+  );
+
+drop policy if exists aso_historico_select_owner on public.aso_historico;
+drop policy if exists aso_historico_insert_owner on public.aso_historico;
+
+create policy aso_historico_select_owner
+  on public.aso_historico
+  for select
+  to authenticated
+  using (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.read'::text)
+      or public.has_permission('pessoas.write'::text)
+    )
+  );
+
+create policy aso_historico_insert_owner
+  on public.aso_historico
+  for insert
+  to authenticated
+  with check (
+    (public.is_master() or account_owner_id = public.my_owner_id())
+    and (
+      public.is_master()
+      or public.has_permission('pessoas.write'::text)
+    )
+  );
+
+create or replace function public.rpc_aso_create_full(
+  p_pessoa_id uuid,
+  p_tipo_exame_id uuid,
+  p_data_exame date,
+  p_observacao text default null,
+  p_usuario_id uuid default null
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := public.is_master();
+  v_user uuid := case when v_is_master and p_usuario_id is not null then p_usuario_id else auth.uid() end;
+  v_row_owner uuid;
+  v_id uuid;
+  v_after jsonb;
+begin
+  if not v_is_master and not public.has_permission('pessoas.write'::text) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_owner is null and not v_is_master then
+    raise exception 'owner_not_resolved' using errcode = '42501';
+  end if;
+
+  select p.account_owner_id
+    into v_row_owner
+  from public.pessoas p
+  where p.id = p_pessoa_id;
+
+  if v_row_owner is null then
+    raise exception 'pessoa_not_found' using errcode = 'P0001';
+  end if;
+
+  if not v_is_master and v_row_owner <> v_owner then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if exists (
+    select 1
+    from public.aso_controle aso
+    where aso.account_owner_id = v_row_owner
+      and aso.pessoa_id = p_pessoa_id
+      and aso.tipo_exame_id = p_tipo_exame_id
+  ) then
+    raise exception 'aso_duplicate'
+      using errcode = '23505',
+            message = 'Ja existe um ASO deste tipo para o funcionario informado.';
+  end if;
+
+  insert into public.aso_controle (
+    pessoa_id,
+    tipo_exame_id,
+    data_exame,
+    observacao,
+    usuario_cadastro,
+    account_owner_id
+  ) values (
+    p_pessoa_id,
+    p_tipo_exame_id,
+    p_data_exame,
+    p_observacao,
+    v_user,
+    v_row_owner
+  )
+  returning id into v_id;
+
+  select to_jsonb(vw)
+    into v_after
+  from public.aso_controle_view vw
+  where vw.id = v_id;
+
+  insert into public.aso_historico (
+    aso_id,
+    pessoa_id,
+    acao,
+    dados_antes,
+    dados_depois,
+    observacao,
+    usuario_responsavel,
+    account_owner_id
+  ) values (
+    v_id,
+    p_pessoa_id,
+    'cadastro',
+    null,
+    coalesce(v_after, '{}'::jsonb),
+    p_observacao,
+    v_user,
+    v_row_owner
+  );
+
+  return query
+    select vw.*
+    from public.aso_controle_view vw
+    where vw.id = v_id
+      and (v_is_master or vw.account_owner_id = v_owner);
+end;
+$$;
+
+revoke all on function public.rpc_aso_create_full(
+  uuid,
+  uuid,
+  date,
+  text,
+  uuid
+) from public;
+
+grant execute on function public.rpc_aso_create_full(
+  uuid,
+  uuid,
+  date,
+  text,
+  uuid
+) to authenticated;
+
+create or replace function public.rpc_aso_update_full(
+  p_id uuid,
+  p_tipo_exame_id uuid,
+  p_data_exame date,
+  p_observacao text default null,
+  p_usuario_id uuid default null,
+  p_acao text default 'edicao'
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := public.is_master();
+  v_user uuid := case when v_is_master and p_usuario_id is not null then p_usuario_id else auth.uid() end;
+  v_row_owner uuid;
+  v_pessoa_id uuid;
+  v_before jsonb;
+  v_after jsonb;
+  v_acao text := case when p_acao in ('edicao', 'registro_exame') then p_acao else 'edicao' end;
+begin
+  if not v_is_master and not public.has_permission('pessoas.write'::text) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_owner is null and not v_is_master then
+    raise exception 'owner_not_resolved' using errcode = '42501';
+  end if;
+
+  select
+    aso.account_owner_id,
+    aso.pessoa_id
+  into
+    v_row_owner,
+    v_pessoa_id
+  from public.aso_controle aso
+  where aso.id = p_id;
+
+  if v_row_owner is null then
+    raise exception 'aso_not_found' using errcode = 'P0001';
+  end if;
+
+  if not v_is_master and v_row_owner <> v_owner then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if exists (
+    select 1
+    from public.aso_controle aso
+    where aso.account_owner_id = v_row_owner
+      and aso.pessoa_id = v_pessoa_id
+      and aso.tipo_exame_id = p_tipo_exame_id
+      and aso.id <> p_id
+  ) then
+    raise exception 'aso_duplicate'
+      using errcode = '23505',
+            message = 'Ja existe um ASO deste tipo para o funcionario informado.';
+  end if;
+
+  select to_jsonb(vw)
+    into v_before
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  update public.aso_controle
+     set tipo_exame_id = p_tipo_exame_id,
+         data_exame = p_data_exame,
+         observacao = p_observacao,
+         usuario_edicao = v_user,
+         atualizado_em = now()
+   where id = p_id;
+
+  select to_jsonb(vw)
+    into v_after
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  if coalesce(v_before, '{}'::jsonb) is distinct from coalesce(v_after, '{}'::jsonb) then
+    insert into public.aso_historico (
+      aso_id,
+      pessoa_id,
+      acao,
+      dados_antes,
+      dados_depois,
+      observacao,
+      usuario_responsavel,
+      account_owner_id
+    ) values (
+      p_id,
+      v_pessoa_id,
+      v_acao,
+      v_before,
+      coalesce(v_after, '{}'::jsonb),
+      p_observacao,
+      v_user,
+      v_row_owner
+    );
+  end if;
+
+  return query
+    select vw.*
+    from public.aso_controle_view vw
+    where vw.id = p_id
+      and (v_is_master or vw.account_owner_id = v_owner);
+end;
+$$;
+
+revoke all on function public.rpc_aso_update_full(
+  uuid,
+  uuid,
+  date,
+  text,
+  uuid,
+  text
+) from public;
+
+grant execute on function public.rpc_aso_update_full(
+  uuid,
+  uuid,
+  date,
+  text,
+  uuid,
+  text
+) to authenticated;
+
+create or replace function public.rpc_aso_register_exam(
+  p_id uuid,
+  p_data_realizada date,
+  p_observacao text default null,
+  p_usuario_id uuid default null
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_tipo_exame_id uuid;
+  v_observacao_atual text;
+begin
+  select
+    tipo_exame_id,
+    observacao
+  into
+    v_tipo_exame_id,
+    v_observacao_atual
+  from public.aso_controle
+  where id = p_id;
+
+  if v_tipo_exame_id is null then
+    raise exception 'aso_not_found' using errcode = 'P0001';
+  end if;
+
+  return query
+    select *
+    from public.rpc_aso_update_full(
+      p_id,
+      v_tipo_exame_id,
+      p_data_realizada,
+      coalesce(p_observacao, v_observacao_atual),
+      p_usuario_id,
+      'registro_exame'
+    );
+end;
+$$;
+
+revoke all on function public.rpc_aso_register_exam(
+  uuid,
+  date,
+  text,
+  uuid
+) from public;
+
+grant execute on function public.rpc_aso_register_exam(
+  uuid,
+  date,
+  text,
+  uuid
+) to authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
- O que foi feito:
  - criar migration do dominio de ASO com catalogo de tipos, tabela principal, historico, view e RPCs
  - aplicar regra de proximo vencimento no banco
  - bloquear duplicidade por tenant para funcionario + tipo de exame
  - adicionar rotas e operacoes base de API para listar, cadastrar, editar, registrar exame e consultar historico
  - adicionar services frontend base para ASO
  - atualizar TASKS.md com o estado atual da feature

- Arquivos tocados:
  - supabase/migrations/20260412_create_aso_control.sql
  - api/index.js
  - api/_shared/operations.js
  - src/services/api.js
  - src/services/asoService.js
  - TASKS.md

- Mapeamento por modulo/tela:
  - Banco ASO: tabelas, RLS, triggers, view e RPCs
  - API ASO: endpoints e operacoes para dominio
  - Service ASO: cliente frontend para etapa de UI

- Como validar:
  - npm run build
  - aplicar migration no Supabase
  - testar create/update/registerExam/history do dominio ASO

- Impacto multi-tenant:
  - account_owner_id aplicado em aso_controle e aso_historico
  - RLS por owner usando pessoas.read/pessoas.write
  - duplicidade isolada por tenant

- Docs atualizadas:
  - TASKS.md atualizado