### PR TITLE
feat(rbac): separar permissao da tela Controle de ASO

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,21 @@ supabase/
     20260302_fix_acidentes_cid_update_hash.sql  # migration SQL
     20260303_fix_acidentes_rehash_digest.sql  # migration SQL
     20260304_fix_acidentes_rehash_search_path.sql  # migration SQL
+    20260305_edge_functions_error_report_actor.sql  # migration SQL
+    20260305_expand_permission_dependencies.sql  # migration SQL
+    20260305_prevent_self_demotion.sql  # migration SQL
+    20260306_add_login_name_to_app_users.sql  # migration SQL
+    20260307_add_fk_indexes_advisor_large_tables.sql  # migration SQL
+    20260308_add_api_rate_limits_and_idempotency.sql  # migration SQL
+    20260308_add_plan_burst_limits.sql  # migration SQL
+    20260308_fix_rate_limit_fn_ambiguous.sql  # migration SQL
+    20260308_fix_rate_limit_fn_conflict.sql  # migration SQL
+    20260308_fix_rate_limit_fn_plan_override.sql  # migration SQL
+    20260308_fix_rate_limit_fn_window_start_ambiguous.sql  # migration SQL
+    20260308_fix_rpc_catalog_list_owner_scope.sql  # migration SQL
+    20260308_update_auth_login_rate_limit.sql  # migration SQL
+    20260412_add_aso_page_permissions.sql  # migration SQL
+    20260412_create_aso_control.sql  # migration SQL
   migrations_rebuild/
     0001_extensions.sql  # migration rebuild SQL
     0002_tables.sql  # migration rebuild SQL

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,6 +3,7 @@
 ## Concluido
 - Tela de ASO foi criada com cadastro manual, cards, filtros, lista, detalhes, historico e modal de registro de exame.
 - Navegacao e controle de acesso da tela ASO foram integrados em rota, menu lateral e `permissions.js`.
+- `Credenciais e Permissoes` ganhou toggle proprio para `Controle de ASO`, separado de `Pessoas`, com chaves de pagina dedicadas e backfill de roles/overrides.
 - Documentacao obrigatoria da tela ASO foi criada em `docs/ASO.txt` e o README foi atualizado com a nova estrutura.
 - Base do dominio de ASO foi criada com migration versionada (`aso_tipos_exame`, `aso_controle`, `aso_historico`), view (`aso_controle_view`) e RPCs de create/update/registrar exame.
 - API e services ganharam a base de integracao para ASO (listagem, tipos, cadastro, edicao, registro de exame e historico).
@@ -31,6 +32,8 @@
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
+- Aplicar a migration `supabase/migrations/20260412_add_aso_page_permissions.sql` no projeto Supabase.
+- Revisar a regra de `PermissionsContext` para role `admin`: hoje ela libera todas as rotas, entao os toggles de pagina em `Credenciais e Permissoes` nao restringem navegacao para esse perfil.
 - Publicar/deploy das Edge Functions `aso-template` e `aso-import` no projeto Supabase.
 - Validar no banco o comportamento de `proximo_vencimento`:
   - admissional e periodico somam 1 ano a partir de `data_exame`

--- a/docs/ASO.txt
+++ b/docs/ASO.txt
@@ -7,6 +7,7 @@ Visao geral
 - A tela segue o padrao do sistema com bloco de cadastro, cards resumo, filtros, lista, ajuda contextual, exportacao CSV e historico.
 - O acesso principal foi criado em `/pcsmo/controledeaso`, mantendo alias em `/cadastros/aso`.
 - No menu lateral, a funcionalidade fica na nova secao `PCSMO` como `Controle de ASO`.
+- Em `Credenciais e Permissoes`, a tela usa a chave de pagina `pcsmo.controle_aso`, separada de `Pessoas`.
 - O campo "Proximo ao vencimento" e somente leitura:
   - admissional e periodico somam 1 ano a partir de `data_exame`
   - demissional fica sem renovacao e sem alerta

--- a/docs/Configuracoes.txt
+++ b/docs/Configuracoes.txt
@@ -54,6 +54,20 @@ Atualizacao 2026-03
   - supabase/migrations/20260305_expand_permission_dependencies.sql
   - src/config/permissions.js
 
+Atualizacao 2026-04
+-------------------
+- `Credenciais e Permissoes` passa a exibir `Controle de ASO` como toggle proprio, sem compartilhar a chave da tela `Pessoas`.
+- `Pessoas` passa a usar a chave de pagina `cadastros.pessoas`.
+- `Controle de ASO` passa a usar a chave de pagina `pcsmo.controle_aso`.
+- As duas chaves expandem para `pessoas.read` e `pessoas.write`, mantendo a RLS e os catalogos de pessoa.
+- A migration faz backfill de roles e overrides legados baseados em `pessoas.write` para evitar perda de acesso apos o deploy.
+- Arquivos alterados:
+  - src/config/permissions.js
+  - supabase/migrations/20260412_add_aso_page_permissions.sql
+  - docs/Configuracoes.txt
+  - docs/CredenciaisPermissoes.txt
+  - docs/PermissoesToggles.txt
+
 Integracao com Supabase
 -----------------------
 - Leitura/escrita: tabelas app_users, user_roles, user_permission_overrides, app_users_credential_history.
@@ -76,7 +90,7 @@ Notas de UX
 - Status toggles usam texto Ativo/Inativo e feedback textual.
 
 
-- Toggles de permissao usam PERMISSION_GROUPS com chaves por pagina (ex.: estoque.atual, estoque.relatorio), evitando vinculos entre switches. Ver detalhes em docs/PermissoesToggles.txt.
+- Toggles de permissao usam PERMISSION_GROUPS com chaves por pagina (ex.: estoque.atual, estoque.relatorio, cadastros.pessoas, pcsmo.controle_aso), evitando vinculos entre switches. Ver detalhes em docs/PermissoesToggles.txt.
 
 - Ajuda contextual: HelpButton top-right, conteudo em src/help/helpConfiguracoes.json; assets em public/help/configuracoes/.
 

--- a/docs/CredenciaisPermissoes.txt
+++ b/docs/CredenciaisPermissoes.txt
@@ -53,6 +53,7 @@ Modelo de dados (Supabase)
 - Seeds de permissions: `estoque.read|write`, `pessoas.read|write`, `acidentes.read|write`, `hht.read|write`,
   `estoque.dashboard`, `dashboard_analise_estoque`, `acidentes.dashboard`, `estoque.atual`, `estoque.entradas`,
   `estoque.saidas`, `estoque.materiais`, `estoque.termo`, `estoque.relatorio`, `estoque.reprocessar`,
+  `cadastros.pessoas`, `pcsmo.controle_aso`,
   `rbac.manage`, `users.manage`, `credentials.manage`.
 
 - Mapeamentos principais:
@@ -155,7 +156,7 @@ Fluxo de uso (frontend)
 
 - Navegacao/Rotas:
 
-  - `permissions.js`: `PAGE_CATALOG` e `PAGE_REQUIRED_PERMISSION` (ex.: dashboard -> estoque.dashboard, dashboard-acidentes -> acidentes.dashboard, entradas -> estoque.entradas, saidas -> estoque.saidas, pessoas -> pessoas.write, materiais -> estoque.materiais, termo -> estoque.termo, hht -> hht.write, configuracoes -> rbac.manage).
+  - `permissions.js`: `PAGE_CATALOG` e `PAGE_REQUIRED_PERMISSION` (ex.: dashboard -> estoque.dashboard, dashboard-acidentes -> acidentes.dashboard, entradas -> estoque.entradas, saidas -> estoque.saidas, pessoas -> cadastros.pessoas, controle de ASO -> pcsmo.controle_aso, materiais -> estoque.materiais, termo -> estoque.termo, hht -> hht.write, configuracoes -> rbac.manage).
 
   - `resolveAllowedPaths`: paths liberados; master ignora checagem.
 
@@ -165,6 +166,7 @@ Fluxo de uso (frontend)
 
 - `permissions.js` usa chaves por pagina (ex.: `estoque.atual`, `estoque.relatorio`, `estoque.entradas`).
 - RLS continua validando dominios (`estoque.read|write`, `acidentes.read|write` etc). As chaves por pagina servem para menu/rotas.
+- `cadastros.pessoas` e `pcsmo.controle_aso` ficam separados na UI, mas ambos expandem para `pessoas.read` e `pessoas.write` para atender a RLS do dominio de pessoas/ASO.
 
 
 
@@ -240,6 +242,17 @@ Resolvido (2026-02)
 - PAGE_REQUIRED_PERMISSION atualizado para chaves por pagina.
 - Migration adiciona permissoes e mapeia roles para manter comportamento.
 - Ver detalhes em docs/PermissoesToggles.txt.
+
+Atualizacao 2026-04 (pessoas e ASO)
+-----------------------------------
+- `Pessoas` e `Controle de ASO` deixaram de compartilhar a chave `pessoas.write` na navegacao.
+- Foram criadas as chaves de pagina `cadastros.pessoas` e `pcsmo.controle_aso`.
+- A migration replica roles e overrides legados baseados em `pessoas.write` para evitar quebra apos o deploy.
+- Arquivos alterados:
+- `src/config/permissions.js`
+- `supabase/migrations/20260412_add_aso_page_permissions.sql`
+- `docs/Configuracoes.txt`
+- `docs/PermissoesToggles.txt`
 
 Atualizacao 2026-02 (permissoes)
 --------------------------------

--- a/docs/PermissoesToggles.txt
+++ b/docs/PermissoesToggles.txt
@@ -27,10 +27,22 @@ Atualizacao 2026-03 (dependencias de permissao)
 - Mantem toggles independentes, mas garante RLS para dados base.
 - A expansao agora tambem roda no banco (`has_permission` e `resolve_user_permissions`), entao dependentes antigos passam a receber as permissoes base sem precisar salvar novamente.
 
+Atualizacao 2026-04 (Pessoas e Controle de ASO)
+- `Pessoas` e `Controle de ASO` passam a ter toggles independentes.
+- Novas chaves: `cadastros.pessoas` e `pcsmo.controle_aso`.
+- As duas expandem para `pessoas.read` e `pessoas.write`, preservando a RLS do dominio.
+- A migration tambem faz backfill de `user_permission_overrides` herdados de `pessoas.write` para evitar acesso quebrado ou pagina liberada com backend negando acao.
+
 Arquivos:
 - src/config/permissions.js
 - src/pages/Configuracoes.jsx
 - supabase/migrations/20260305_expand_permission_dependencies.sql
+
+Arquivos:
+- src/config/permissions.js
+- supabase/migrations/20260412_add_aso_page_permissions.sql
+- docs/Configuracoes.txt
+- docs/CredenciaisPermissoes.txt
 
 Arquivos:
 - src/config/permissions.js

--- a/src/config/permissions.js
+++ b/src/config/permissions.js
@@ -27,8 +27,8 @@ const PAGE_REQUIRED_PERMISSION = {
   estoque: 'estoque.atual',
   entradas: 'estoque.entradas',
   saidas: 'estoque.saidas',
-  'cadastros-pessoas': 'pessoas.write',
-  'cadastros-aso': 'pessoas.write',
+  'cadastros-pessoas': 'cadastros.pessoas',
+  'cadastros-aso': 'pcsmo.controle_aso',
   'cadastros-materiais': 'estoque.materiais',
   'cadastros-base': 'basic_registration.write',
   'acidentes-cadastro': 'acidentes.write',
@@ -114,6 +114,8 @@ const PERMISSION_LABELS = {
   'estoque.termo': 'Termo de EPI',
   'estoque.relatorio': 'Relatorio de Estoque',
   'estoque.reprocessar': 'Estoque - Reprocessar previsao',
+  'cadastros.pessoas': 'Pessoas',
+  'pcsmo.controle_aso': 'Controle de ASO',
   'pessoas.read': 'Pessoas - Ler',
   'pessoas.write': 'Pessoas - Alterar',
   'acidentes.read': 'Acidentes - Ler',
@@ -138,7 +140,8 @@ const PERMISSION_GROUPS = [
   { id: 'estoque-reprocessar', label: 'Reprocessar previsao', keys: ['estoque.reprocessar'] },
   { id: 'acidentes', label: 'Cadastro de Acidentes', keys: ['acidentes.read', 'acidentes.write'] },
   { id: 'hht', label: 'HHT Mensal', keys: ['hht.read', 'hht.write'] },
-  { id: 'pessoas', label: 'Pessoas', keys: ['pessoas.read', 'pessoas.write'] },
+  { id: 'pessoas', label: 'Pessoas', keys: ['cadastros.pessoas'] },
+  { id: 'controle-aso', label: 'Controle de ASO', keys: ['pcsmo.controle_aso'] },
   { id: 'cadastro-base', label: 'Cadastro Base', keys: ['basic_registration.read', 'basic_registration.write'] },
 ]
 
@@ -152,6 +155,8 @@ const PERMISSION_DEPENDENCIES = {
   'estoque.termo': ['estoque.read', 'pessoas.read'],
   'estoque.relatorio': ['estoque.read'],
   'estoque.reprocessar': ['estoque.read'],
+  'cadastros.pessoas': ['pessoas.read', 'pessoas.write'],
+  'pcsmo.controle_aso': ['pessoas.read', 'pessoas.write'],
   'acidentes.dashboard': ['acidentes.read'],
 }
 

--- a/supabase/migrations/20260412_add_aso_page_permissions.sql
+++ b/supabase/migrations/20260412_add_aso_page_permissions.sql
@@ -1,0 +1,78 @@
+-- Adiciona chaves de permissao por pagina para Pessoas e Controle de ASO.
+
+insert into public.permissions (key, description) values
+  ('cadastros.pessoas', 'Pessoas'),
+  ('pcsmo.controle_aso', 'Controle de ASO')
+on conflict (key) do update
+set description = excluded.description;
+
+-- Roles que ja podem alterar Pessoas passam a receber as paginas Pessoas e Controle de ASO.
+insert into public.role_permissions (role_id, permission_id)
+select distinct rp.role_id, p_new.id
+from public.role_permissions rp
+join public.permissions p_old on p_old.id = rp.permission_id
+join public.permissions p_new on p_new.key in ('cadastros.pessoas', 'pcsmo.controle_aso')
+where p_old.key = 'pessoas.write'
+on conflict do nothing;
+
+-- Backfill de overrides legados para manter o comportamento de acesso por pagina.
+insert into public.user_permission_overrides (user_id, permission_key, allowed)
+select upo.user_id, mapped.permission_key, upo.allowed
+from public.user_permission_overrides upo
+cross join (
+  values ('cadastros.pessoas'), ('pcsmo.controle_aso')
+) as mapped(permission_key)
+where upo.permission_key = 'pessoas.write'
+on conflict (user_id, permission_key) do update
+set allowed = excluded.allowed;
+
+-- Expande chaves de pagina para as permissoes base exigidas pela RLS.
+create or replace function public.expand_permission_dependencies(p_permissions text[])
+returns text[]
+language sql
+immutable
+set search_path = public
+as $$
+  with recursive deps(permission_key) as (
+    select distinct nullif(btrim(value), '')
+    from unnest(coalesce(p_permissions, '{}'::text[])) as value
+
+    union
+
+    select mapping.depends_on
+    from deps
+    join (
+      values
+        ('estoque.dashboard', 'estoque.read'),
+        ('dashboard_analise_estoque', 'estoque.read'),
+        ('estoque.atual', 'estoque.read'),
+        ('estoque.entradas', 'estoque.read'),
+        ('estoque.saidas', 'estoque.read'),
+        ('estoque.saidas', 'pessoas.read'),
+        ('estoque.materiais', 'estoque.read'),
+        ('estoque.termo', 'estoque.read'),
+        ('estoque.termo', 'pessoas.read'),
+        ('estoque.relatorio', 'estoque.read'),
+        ('estoque.reprocessar', 'estoque.read'),
+        ('cadastros.pessoas', 'pessoas.read'),
+        ('cadastros.pessoas', 'pessoas.write'),
+        ('pcsmo.controle_aso', 'pessoas.read'),
+        ('pcsmo.controle_aso', 'pessoas.write'),
+        ('acidentes.dashboard', 'acidentes.read')
+    ) as mapping(permission_key, depends_on)
+      on mapping.permission_key = deps.permission_key
+    where nullif(btrim(mapping.depends_on), '') is not null
+  )
+  select coalesce(
+    array(
+      select distinct permission_key
+      from deps
+      where permission_key is not null
+      order by permission_key
+    ),
+    '{}'::text[]
+  );
+$$;
+
+comment on function public.expand_permission_dependencies(text[]) is
+  'Expande permissoes de pagina em permissoes base exigidas pela RLS.';


### PR DESCRIPTION
- O que foi feito:
  - criada a permissao de pagina `pcsmo.controle_aso` para a tela Controle de ASO
  - separada a tela Pessoas para usar `cadastros.pessoas`
  - adicionada migration com seed de permissions, backfill de role_permissions e user_permission_overrides
  - expand_permission_dependencies passou a incluir as novas chaves de pagina
  - documentacao de Configuracoes, Credenciais e ASO foi atualizada
  - TASKS.md e README.md foram ajustados ao estado atual

- Arquivos:
  - src/config/permissions.js
  - supabase/migrations/20260412_add_aso_page_permissions.sql
  - docs/Configuracoes.txt
  - docs/CredenciaisPermissoes.txt
  - docs/PermissoesToggles.txt
  - docs/ASO.txt
  - TASKS.md
  - README.md

- Mapeamento:
  - Configuracoes: toggle proprio para Controle de ASO e separacao de Pessoas por chave de pagina
  - RBAC/Supabase: novo seed de permissions + backfill de roles/overrides
  - ASO: documentada a chave `pcsmo.controle_aso` em Credenciais e Permissoes

- Como validar:
  - npm run build
  - aplicar migration 20260412_add_aso_page_permissions.sql
  - validar v_me/permissoes e acesso a /pcsmo/controledeaso
  - validar tela Configuracoes com o novo toggle

- Impacto multi-tenant:
  - sem mudanca de escopo entre tenants
  - RLS continua dependente de pessoas.read/pessoas.write, agora herdadas pelas novas chaves de pagina

- Docs:
  - docs/Configuracoes.txt atualizado
  - docs/CredenciaisPermissoes.txt atualizado
  - docs/PermissoesToggles.txt atualizado
  - docs/ASO.txt atualizado