### PR TITLE
feat(aso): implementar baixa de exame com novo ciclo e historico enxuto

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,7 @@ supabase/
     20260308_fix_rpc_catalog_list_owner_scope.sql  # migration SQL
     20260308_update_auth_login_rate_limit.sql  # migration SQL
     20260412_add_aso_page_permissions.sql  # migration SQL
+    20260412_aso_baixa_e_historico.sql  # migration SQL
     20260412_create_aso_control.sql  # migration SQL
   migrations_rebuild/
     0001_extensions.sql  # migration rebuild SQL

--- a/TASKS.md
+++ b/TASKS.md
@@ -15,6 +15,7 @@
   - periodico alerta sobre possivel duplicidade na janela de 15 dias e pode continuar
   - demissional exige pessoa inativa ou com `dataDemissao`
 - Cadastro em massa de ASO foi implementado com template XLSX, upload para Storage, Edge Function de importacao e CSV de erros.
+- Fluxo de baixa do ASO passou a fechar o registro atual como `Baixado`, criar um novo ciclo com a data realizada e registrar historico apenas em edicao/baixa.
 - Tela de reset de senha passou a traduzir o erro de senha repetida para portugues e ganhou exibicao/ocultacao por icone de olho nos campos de senha.
 - Removida a reautenticacao obrigatoria nas rotas protegidas do backend/front.
 - Fluxo de reset de senha voltou a usar Supabase direto com `token_hash` na tela de reset.
@@ -33,6 +34,7 @@
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260412_add_aso_page_permissions.sql` no projeto Supabase.
+- Aplicar a migration `supabase/migrations/20260412_aso_baixa_e_historico.sql` no projeto Supabase.
 - Revisar a regra de `PermissionsContext` para role `admin`: hoje ela libera todas as rotas, entao os toggles de pagina em `Credenciais e Permissoes` nao restringem navegacao para esse perfil.
 - Publicar/deploy das Edge Functions `aso-template` e `aso-import` no projeto Supabase.
 - Validar no banco o comportamento de `proximo_vencimento`:

--- a/api/_shared/operations.js
+++ b/api/_shared/operations.js
@@ -609,6 +609,10 @@ function mapAsoRecord(record) {
     usuarioEdicaoNome: record.usuario_edicao_nome ?? record.usuarioEdicaoNome ?? '',
     criadoEm: record.criado_em ?? record.criadoEm ?? null,
     atualizadoEm: record.atualizado_em ?? record.atualizadoEm ?? null,
+    statusRegistro: record.status_registro ?? record.statusRegistro ?? 'ativo',
+    registroOrigemId: record.registro_origem_id ?? record.registroOrigemId ?? null,
+    baixadoEm: record.baixado_em ?? record.baixadoEm ?? null,
+    baixadoPor: record.baixado_por ?? record.baixadoPor ?? null,
     accountOwnerId: record.account_owner_id ?? record.accountOwnerId ?? null,
   }
 }
@@ -627,6 +631,14 @@ function normalizeAsoHistory(lista) {
         asoId: registro.aso_id ?? registro.asoId ?? null,
         pessoaId: registro.pessoa_id ?? registro.pessoaId ?? null,
         acao: trim(registro.acao ?? ''),
+        acaoLabel:
+          trim(registro.acao ?? '') === 'baixa_exame'
+            ? 'Baixa de exame'
+            : trim(registro.acao ?? '') === 'registro_exame'
+              ? 'Baixa de exame'
+            : trim(registro.acao ?? '') === 'edicao'
+              ? 'Edicao'
+              : trim(registro.acao ?? ''),
         criadoEm: registro.criado_em ?? registro.criadoEm ?? null,
         observacao: registro.observacao ?? '',
         usuarioResponsavelId:
@@ -2110,7 +2122,11 @@ export const PessoasOperations = {
 export const AsoOperations = {
   async list(params = {}, user = {}) {
     const ownerId = user?.id ? await resolveOwnerId(user.id) : null
-    let query = supabaseAdmin.from('aso_controle_view').select('*').order('proximo_vencimento', { ascending: true })
+    let query = supabaseAdmin
+      .from('aso_controle_view')
+      .select('*')
+      .order('status_registro', { ascending: true })
+      .order('proximo_vencimento', { ascending: true })
 
     if (ownerId) {
       query = query.eq('account_owner_id', ownerId)
@@ -2250,7 +2266,7 @@ export const AsoOperations = {
     const client = buildUserClient(authToken)
     const registro = await executeSingle(
       client.rpc('rpc_aso_register_exam', params),
-      'Falha ao registrar exame.'
+      'Falha ao dar baixa no exame.'
     )
 
     return mapAsoRecord(registro)
@@ -2266,6 +2282,7 @@ export const AsoOperations = {
         .from('aso_historico')
         .select('id, aso_id, pessoa_id, acao, dados_antes, dados_depois, observacao, usuario_responsavel, criado_em')
         .eq('aso_id', id)
+        .neq('acao', 'cadastro')
         .order('criado_em', { ascending: true }),
       'Falha ao obter historico do ASO.'
     )

--- a/api/index.js
+++ b/api/index.js
@@ -104,7 +104,7 @@ export default withAuth(async (req, res, user) => {
     if (path.startsWith('/api/aso/register-exam/') && method === 'POST') {
       const id = path.split('/')[4]
       if (!id) {
-        throw createHttpError(400, 'ID do ASO nao informado para registrar exame.', {
+        throw createHttpError(400, 'ID do ASO nao informado para baixa do exame.', {
           code: 'VALIDATION_ERROR',
         })
       }

--- a/docs/ASO.txt
+++ b/docs/ASO.txt
@@ -12,24 +12,23 @@ Visao geral
   - admissional e periodico somam 1 ano a partir de `data_exame`
   - demissional fica sem renovacao e sem alerta
 - Historico de multiplos registros e obrigatorio:
-  - cadastro inicial
   - edicao
-  - registrar exame
+  - baixa de exame
 
 Arquitetura
 -----------
 - Contexto:
   - `AsoProvider` (`AsoContext`) expoe o estado e as acoes do hook `useAsoController`.
 - Hook `useAsoController`:
-  - centraliza formulario, busca de funcionario, filtros, listagem, exportacao, historico, modal "Registrar exame" e modal de conflito
+  - centraliza formulario, busca de funcionario, filtros, listagem, exportacao, historico, modal de baixa e modal de conflito
   - integra erros com `useErrorLogger('aso')`
 - Servicos:
-  - `asoService` encapsula listagem, tipos, cadastro, edicao, registro de exame e historico
+  - `asoService` encapsula listagem, tipos, cadastro, edicao, baixa de exame e historico
   - `api.js` expande o `dataClient` com o dominio `aso`
 - Banco:
   - `aso_tipos_exame`: catalogo fixo de tipos de exame
   - `aso_controle`: estado atual do ASO por funcionario/tipo/data
-  - `aso_historico`: auditoria de cadastro, edicao e registro de exame
+  - `aso_historico`: auditoria apenas de alteracoes reais (edicao e baixa de exame)
   - `aso_controle_view`: view pronta para lista/cards/filtros com dados de pessoa (`ativo`, `dataDemissao`)
 
 Cadastro
@@ -55,7 +54,7 @@ Cadastro
   - upload vai para `imports/<owner_id>/aso/<uuid>-<arquivo>.xlsx`
   - a Edge Function valida JWT, prefixo do owner, limite do plano e rate limit
   - linhas invalidas retornam em CSV de erros assinado
-  - a importacao reaproveita `rpc_aso_create_full` para manter historico e regras do banco
+  - a importacao reaproveita `rpc_aso_create_full` para manter as regras do banco
 - Modal de conflito:
   - admissional/demissional:
     - titulo "Exame ja cadastrado"
@@ -90,10 +89,15 @@ Filtros, auto-complete e listagem
   - Demissionais
 - Tabela:
   - Colunas: Funcionario, Matricula, Tipo de exame, Data do exame, Proximo vencimento, Dias para vencer, Status, Cadastrado em, Acoes
-  - Acoes: Ver detalhes, Editar, Historico, Registrar exame
-  - `Registrar exame` fica desabilitado para demissional
+  - Acoes: Ver detalhes, Editar, Historico, Dar baixa no exame
+  - `Dar baixa no exame` fica desabilitado para demissional e para registros ja baixados
   - legenda de vencimento segue o padrao visual da tela Saidas
   - botao `Exportar Excel (CSV)` exporta a lista filtrada no formato CSV
+- Fluxo de baixa:
+  - a baixa fecha o registro atual com status `Baixado`
+  - a linha original permanece na lista como historico operacional
+  - um novo registro e criado com a `data realizada` informada no modal
+  - o proximo vencimento do novo registro e recalculado automaticamente
 - Datas:
   - exibicao usa parser local para evitar deslocamento de dia em `YYYY-MM-DD`
   - o problema anterior de data ISO/UTC foi corrigido em formulario, tabela, detalhes, historico e exportacao
@@ -109,11 +113,12 @@ Boas praticas
   - UUID aleatorio so faria mais sentido se esse catalogo virasse cadastro livre/administravel
 - Preferir o calculo de vencimento no banco para manter consistencia entre frontend, API e importacao futura.
 - Mudancas de exame devem passar pelo historico para manter auditoria.
+- Cadastro inicial nao gera historico proprio; o historico fica reservado para alteracoes reais.
 - Em caso de correcao de data para admissional/demissional, editar o registro existente em vez de criar outro.
 
 Atualizacao 2026-04
 -------------------
-- Criado o dominio inicial de ASO com tela manual, cards, filtros, lista, detalhes, historico e modal `Registrar exame`.
+- Criado o dominio inicial de ASO com tela manual, cards, filtros, lista, detalhes, historico e modal de baixa.
 - Criadas migration, view e RPCs especificas para o fluxo.
 - `Cadastrar em massa` ficou reservado para a etapa de importacao.
 
@@ -125,14 +130,22 @@ Atualizacao 2026-04 (regras)
 - Datas corrigidas para exibicao no padrao brasileiro sem deslocamento por timezone.
 - Regras de duplicidade ajustadas:
   - banco bloqueia duplicidade exata por funcionario + tipo + data
-  - admissional e demissional bloqueiam novo cadastro por funcionario
+  - admissional e demissional bloqueiam novo cadastro por funcionario enquanto houver registro ativo
   - periodico alerta em janela de 15 dias e permite continuar
 - Demissional passou a exigir funcionario inativo ou com `dataDemissao`.
+
+Atualizacao 2026-04 (baixa e ciclo)
+-----------------------------------
+- A acao da lista deixa de apenas atualizar a linha e passa a funcionar como baixa do ciclo.
+- O registro atual muda para `Baixado` e permanece visivel na lista.
+- A baixa cria um novo registro com a data realizada e novo proximo vencimento.
+- O historico deixa de registrar cadastro inicial e passa a guardar apenas edicao e baixa de exame.
+- As cores de `60 dias`, `30 dias` e `15 dias` foram separadas melhor na legenda, chips e linhas.
 
 Atualizacao 2026-04 (importacao)
 --------------------------------
 - `Cadastrar em massa` implementado com template XLSX e importacao via Edge Function.
-- O fluxo importa por matricula, resolve o tipo de exame pelo catalogo e chama `rpc_aso_create_full` para manter auditoria/historico.
+- O fluxo importa por matricula, resolve o tipo de exame pelo catalogo e chama `rpc_aso_create_full` para manter as regras do banco.
 - O retorno da importacao mostra processados/importados/erros e libera CSV para linhas rejeitadas.
 
 ===========================================
@@ -148,7 +161,7 @@ Funcoes principais
 - useAsoController
   - Tipo: hook/controller
   - Caminho: src/hooks/useAsoController.js
-  - Responsavel por: estado de formulario, busca de pessoa, filtros, submit, pre-validacao de duplicidade, historico e modal de registro.
+  - Responsavel por: estado de formulario, busca de pessoa, filtros, submit, pre-validacao de duplicidade, historico e modal de baixa.
 - AsoContext
   - Tipo: contexto
   - Caminho: src/context/AsoContext.jsx
@@ -167,14 +180,14 @@ Constantes e configuracoes
 - Defaults de formulario/filtros/modais
   - Tipo: constantes
   - Caminho: src/config/AsoConfig.js
-  - Uso: estados iniciais da tela, modal de registrar exame e modal de conflito.
+  - Uso: estados iniciais da tela, modal de baixa de exame e modal de conflito.
 
 Funcoes utilitarias relacionadas
 --------------------------------
 - asoUtils
   - Tipo: utilitarios
   - Caminho: src/utils/asoUtils.js
-  - Responsavel por: parse/formatacao de datas, status, cards, comparacao de historico e calculo de vencimento.
+  - Responsavel por: parse/formatacao de datas, status, cards, comparacao de historico, rotulos de acao e calculo de vencimento.
 - asoExport
   - Tipo: utilitarios
   - Caminho: src/utils/asoExport.js
@@ -185,11 +198,11 @@ Servicos e integracoes externas
 - asoService
   - Tipo: service frontend
   - Caminho: src/services/asoService.js
-  - Responsavel por: expor o dominio `aso` do `dataClient`, incluindo download do modelo e importacao em massa.
+  - Responsavel por: expor o dominio `aso` do `dataClient`, incluindo download do modelo, importacao em massa e baixa de exame.
 - api.js
   - Tipo: service frontend
   - Caminho: src/services/api.js
-  - Responsavel por: listar ASOs, tipos, criar, editar, registrar exame e consultar historico.
+  - Responsavel por: listar ASOs, tipos, criar, editar, dar baixa no exame e consultar historico.
 - API serverless
   - Tipo: backend Vercel
   - Caminho: api/index.js e api/_shared/operations.js
@@ -202,6 +215,10 @@ Servicos e integracoes externas
   - Tipo: banco
   - Caminho: supabase/migrations/20260412_create_aso_control.sql
   - Responsavel por: criar tabelas, view, trigger de vencimento, indices unicos e RPCs.
+- Migration SQL
+  - Tipo: banco
+  - Caminho: supabase/migrations/20260412_aso_baixa_e_historico.sql
+  - Responsavel por: adicionar status de registro, baixa do exame, criacao de novo ciclo e ajuste do historico.
 
 Ajuda contextual
 ----------------
@@ -243,7 +260,8 @@ Comportamento antes/depois
 - Depois:
   - a tela tambem atende em `/pcsmo/controledeaso`
   - a exibicao de datas ficou em padrao brasileiro sem deslocamento
-  - a lista ganhou ajuda, legenda, exportacao CSV e cadastro em massa
+  - a lista ganhou ajuda, legenda, exportacao CSV, cadastro em massa e baixa operacional do exame
   - o banco bloqueia duplicidade exata por `funcionario + tipo + data`
-  - admissional/demissional bloqueiam novo cadastro por funcionario
+  - admissional/demissional bloqueiam novo cadastro por funcionario enquanto houver registro ativo
   - periodico alerta em janela de 15 dias, com opcao de continuar
+  - o historico mostra apenas alteracoes reais, sem registrar o cadastro inicial

--- a/src/components/Aso/AsoActions.jsx
+++ b/src/components/Aso/AsoActions.jsx
@@ -48,9 +48,15 @@ export function AsoActions({
         type="button"
         className="materiais-table-action-button"
         onClick={() => onRegisterExam?.(aso)}
-        disabled={isSaving || isDemissional}
-        aria-label={`Registrar exame do ASO ${aso?.matricula || ''}`}
-        title={isDemissional ? 'Demissional nao possui renovacao' : 'Registrar exame'}
+        disabled={isSaving || isDemissional || aso?.statusRegistro === 'baixado'}
+        aria-label={`Dar baixa no exame do ASO ${aso?.matricula || ''}`}
+        title={
+          isDemissional
+            ? 'Demissional nao possui renovacao'
+            : aso?.statusRegistro === 'baixado'
+              ? 'Registro ja baixado'
+              : 'Dar baixa no exame'
+        }
       >
         <PlusCircleIcon size={16} strokeWidth={1.8} />
       </button>

--- a/src/components/Aso/AsoFilters.jsx
+++ b/src/components/Aso/AsoFilters.jsx
@@ -46,7 +46,8 @@ export function AsoFilters({
             <option value="vence_15">Vencendo em 15 dias</option>
             <option value="vence_hoje">Vence hoje</option>
             <option value="vencido">Vencidos</option>
-            <option value="demissional">Demissional</option>
+            <option value="baixado">Baixado</option>
+            <option value="sem_renovacao">Sem renovacao</option>
           </select>
         </label>
 

--- a/src/components/Aso/AsoHistoryTimeline.jsx
+++ b/src/components/Aso/AsoHistoryTimeline.jsx
@@ -9,7 +9,7 @@ export function AsoHistoryTimeline({ registros = [] }) {
           <article key={registro.id} className="aso-history-entry">
             <header className="aso-history-entry__header">
               <div>
-                <strong>{registro.acao || 'acao nao informada'}</strong>
+                <strong>{registro.acaoLabel || registro.acao || 'acao nao informada'}</strong>
                 <p className="data-table__muted">
                   {registro.usuarioResponsavel || 'sistema'} | {formatDateTime(registro.criadoEm)}
                 </p>
@@ -23,7 +23,7 @@ export function AsoHistoryTimeline({ registros = [] }) {
             ) : null}
 
             {changes.length === 0 ? (
-              <p className="feedback">Registro criado.</p>
+              <p className="feedback">Nenhuma alteracao registrada.</p>
             ) : (
               <ul className="aso-history-entry__changes">
                 {changes.map((change, index) => (

--- a/src/components/Aso/AsoImportModal.jsx
+++ b/src/components/Aso/AsoImportModal.jsx
@@ -141,7 +141,7 @@ export function AsoImportModal({
               <li>Tipo de exame deve ser admissional, periodico ou demissional.</li>
               <li>Data do exame deve estar em dd/MM/yyyy ou formato de data do Excel.</li>
               <li>Bloqueia duplicidade exata por matricula + tipo + data.</li>
-              <li>Admissional e demissional bloqueiam novo cadastro para a mesma matricula.</li>
+              <li>Admissional e demissional bloqueiam novo cadastro enquanto houver registro ativo para a mesma matricula.</li>
               <li>Demissional exige pessoa inativa ou com data de desligamento.</li>
             </ul>
           </details>

--- a/src/components/Aso/AsoRegisterExamModal.jsx
+++ b/src/components/Aso/AsoRegisterExamModal.jsx
@@ -14,7 +14,7 @@ export function AsoRegisterExamModal({
     <div className="modal__overlay" role="dialog" aria-modal="true" onClick={onClose}>
       <div className="modal__content" onClick={(event) => event.stopPropagation()}>
         <header className="modal__header">
-          <h3>Registrar exame</h3>
+          <h3>Baixa de exame</h3>
           <button type="button" className="modal__close" onClick={onClose} aria-label="Fechar">
             x
           </button>
@@ -61,7 +61,7 @@ export function AsoRegisterExamModal({
               Cancelar
             </button>
             <button type="submit" className="button button--primary" disabled={state.isSaving}>
-              {state.isSaving ? 'Salvando...' : 'Salvar'}
+              {state.isSaving ? 'Salvando...' : 'Confirmar baixa'}
             </button>
           </footer>
         </form>

--- a/src/components/Aso/AsoTable.jsx
+++ b/src/components/Aso/AsoTable.jsx
@@ -35,7 +35,7 @@ export function AsoTable({
     <>
       <div className="saidas-legend" aria-label="Legenda dos vencimentos de ASO">
         <div className="saidas-legend__item">
-          <span className="saidas-legend__dot saidas-legend__dot--alerta" aria-hidden="true" />
+          <span className="saidas-legend__dot aso-legend__dot--60" aria-hidden="true" />
           <span>60 a 31 dias</span>
         </div>
         <div className="saidas-legend__item">
@@ -53,6 +53,10 @@ export function AsoTable({
         <div className="saidas-legend__item">
           <span className="saidas-legend__dot saidas-legend__dot--atrasada" aria-hidden="true" />
           <span>Vencido</span>
+        </div>
+        <div className="saidas-legend__item">
+          <span className="saidas-legend__dot aso-legend__dot--baixado" aria-hidden="true" />
+          <span>Baixado</span>
         </div>
       </div>
 

--- a/src/help/helpAso.json
+++ b/src/help/helpAso.json
@@ -19,9 +19,9 @@
         "mediaHint": "Cards, filtros e legenda acima da tabela."
       },
       {
-        "title": "Registrar novo exame",
-        "description": "Na lista, use o botao Registrar exame para abrir o modal, informar a data realizada e salvar. O sistema atualiza a data do exame, recalcula o vencimento e grava no historico.",
-        "mediaHint": "Modal de registrar exame."
+        "title": "Dar baixa no exame",
+        "description": "Na lista, use o botao de baixa para abrir o modal, informar a data realizada e salvar. O sistema marca o registro atual como baixado, cria um novo ciclo com a data realizada e recalcula o proximo vencimento.",
+        "mediaHint": "Modal de baixa de exame."
       },
       {
         "title": "Tratar duplicidade",
@@ -37,7 +37,7 @@
     "notes": [
       "Campos marcados com * sao obrigatorios.",
       "O banco bloqueia duplicidade exata por funcionario + tipo de exame + data do exame.",
-      "Admissional e demissional sao tratados como unicos por funcionario; para corrigir data, edite o registro existente.",
+      "Admissional e demissional sao tratados como unicos por funcionario enquanto houver registro ativo; para corrigir data, edite o registro existente.",
       "Periodico pode ter varios registros; quando houver outro dentro de 15 dias, a tela alerta antes de salvar.",
       "Demissional nao abre renovacao e nao entra nas contagens de alerta de vencimento.",
       "No cadastro em massa, a matricula precisa existir em Pessoas e o tipo_exame precisa ser admissional, periodico ou demissional."

--- a/src/hooks/useAsoController.js
+++ b/src/hooks/useAsoController.js
@@ -313,7 +313,8 @@ export function useAsoController() {
           (item) =>
             item?.id !== editingAso?.id &&
             item?.pessoaId === payload.pessoaId &&
-            item?.tipoExameId === payload.tipoExameId,
+            item?.tipoExameId === payload.tipoExameId &&
+            item?.statusRegistro !== 'baixado',
         )
         .sort((left, right) => String(right?.dataExame || '').localeCompare(String(left?.dataExame || '')))
 
@@ -476,6 +477,7 @@ export function useAsoController() {
       open: true,
       aso,
       dataRealizada: '',
+      observacao: aso?.observacao ?? '',
     })
   }
 
@@ -506,7 +508,7 @@ export function useAsoController() {
       setRegisterExamState((prev) => ({
         ...prev,
         isSaving: false,
-        error: err.message || 'Falha ao registrar exame.',
+        error: err.message || 'Falha ao dar baixa no exame.',
       }))
       reportError(err, { area: 'aso_register_exam', asoId: registerExamState.aso.id })
     }

--- a/src/services/asoService.js
+++ b/src/services/asoService.js
@@ -39,7 +39,7 @@ export const updateAso = (id, payload) => {
 
 export const registerAsoExam = (id, payload) => {
   if (!api?.aso?.registerExam) {
-    return Promise.reject(new Error('Endpoint de registro de exame nao configurado.'))
+    return Promise.reject(new Error('Endpoint de baixa de exame nao configurado.'))
   }
   return api.aso.registerExam(id, payload)
 }

--- a/src/styles/AsoPage.css
+++ b/src/styles/AsoPage.css
@@ -59,21 +59,21 @@
 }
 
 .aso-status-chip--warning-soft {
-  background: #fff7e6;
-  color: #9a6700;
-  border-color: #f5d08a;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-color: #93c5fd;
 }
 
 .aso-status-chip--warning {
-  background: #fff1db;
-  color: #b45309;
-  border-color: #fbbf24;
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #f59e0b;
 }
 
 .aso-status-chip--warning-strong {
-  background: #ffe7cc;
+  background: #ffedd5;
   color: #c2410c;
-  border-color: #fb923c;
+  border-color: #f97316;
 }
 
 .aso-status-chip--today {
@@ -83,9 +83,15 @@
 }
 
 .aso-status-chip--danger {
-  background: #f3e8ff;
-  color: #7e22ce;
-  border-color: #c084fc;
+  background: #fee2e2;
+  color: #991b1b;
+  border-color: #ef4444;
+}
+
+.aso-status-chip--closed {
+  background: #eef2ff;
+  color: #4338ca;
+  border-color: #a5b4fc;
 }
 
 .aso-status-chip--neutral {
@@ -94,9 +100,14 @@
   border-color: #cbd5e1;
 }
 
+.aso-legend__dot--60 {
+  background: #60a5fa;
+  border-color: #2563eb;
+}
+
 .aso-legend__dot--30 {
-  background: #fb923c;
-  border-color: #ea580c;
+  background: #fbbf24;
+  border-color: #d97706;
 }
 
 .aso-legend__dot--15 {
@@ -104,20 +115,25 @@
   border-color: #c2410c;
 }
 
+.aso-legend__dot--baixado {
+  background: #a5b4fc;
+  border-color: #4f46e5;
+}
+
 .data-table--saidas tbody tr.data-table__row--aso-ok td {
   background: #f0fdf4;
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-warning-soft td {
-  background: #fffbeb;
+  background: #eff6ff;
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-warning td {
-  background: #fff7ed;
+  background: #fffbeb;
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-warning-strong td {
-  background: #ffedd5;
+  background: #fff7ed;
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-today td {
@@ -125,9 +141,13 @@
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-danger td {
-  background: #faf5ff;
+  background: #fef2f2;
 }
 
 .data-table--saidas tbody tr.data-table__row--aso-neutral td {
   background: #f8fafc;
+}
+
+.data-table--saidas tbody tr.data-table__row--aso-closed td {
+  background: #eef2ff;
 }

--- a/src/utils/asoUtils.js
+++ b/src/utils/asoUtils.js
@@ -55,7 +55,8 @@ export const formatDateTime = (value) => {
 export const resolveAsoStatusMeta = (status = '') => {
   const normalized = String(status || '').trim().toLowerCase()
   const map = {
-    demissional: { label: 'Demissional', variant: 'neutral' },
+    ativo: { label: 'Ativo', variant: 'ok' },
+    sem_renovacao: { label: 'Sem renovacao', variant: 'neutral' },
     sem_vencimento: { label: 'Sem vencimento', variant: 'neutral' },
     em_dia: { label: 'Em dia', variant: 'ok' },
     vence_60: { label: 'Vence em 60 dias', variant: 'warning-soft' },
@@ -63,6 +64,7 @@ export const resolveAsoStatusMeta = (status = '') => {
     vence_15: { label: 'Vence em 15 dias', variant: 'warning-strong' },
     vence_hoje: { label: 'Vence hoje', variant: 'today' },
     vencido: { label: 'Vencido', variant: 'danger' },
+    baixado: { label: 'Baixado', variant: 'closed' },
   }
   return map[normalized] || { label: normalized || 'Nao informado', variant: 'neutral' }
 }
@@ -135,11 +137,11 @@ export const buildAsoCards = (lista = []) => {
   const summary = buildAsoSummary(lista)
   return [
     { id: 'total', title: 'Total de registros', value: numberFormatter.format(summary.totalRegistros), variant: 'blue' },
-    { id: '60', title: 'Vencendo em 60 dias', value: numberFormatter.format(summary.vencendo60), variant: 'cyan' },
-    { id: '30', title: 'Vencendo em 30 dias', value: numberFormatter.format(summary.vencendo30), variant: 'amber' },
+    { id: '60', title: 'Vencendo em 60 dias', value: numberFormatter.format(summary.vencendo60), variant: 'blue' },
+    { id: '30', title: 'Vencendo em 30 dias', value: numberFormatter.format(summary.vencendo30), variant: 'green' },
     { id: '15', title: 'Vencendo em 15 dias', value: numberFormatter.format(summary.vencendo15), variant: 'orange' },
     { id: 'hoje', title: 'Vence hoje', value: numberFormatter.format(summary.venceHoje), variant: 'red' },
-    { id: 'vencidos', title: 'Vencidos', value: numberFormatter.format(summary.vencidos), variant: 'danger' },
+    { id: 'vencidos', title: 'Vencidos', value: numberFormatter.format(summary.vencidos), variant: 'slate' },
     { id: 'demissionais', title: 'Demissionais', value: numberFormatter.format(summary.demissionais), variant: 'slate' },
   ]
 }
@@ -152,6 +154,7 @@ const HISTORY_FIELDS = [
   { key: 'proximoVencimento', label: 'Proximo vencimento' },
   { key: 'diasParaVencer', label: 'Dias para vencer' },
   { key: 'statusVencimento', label: 'Status' },
+  { key: 'statusRegistro', label: 'Situacao do registro' },
   { key: 'observacao', label: 'Observacao' },
 ]
 
@@ -172,9 +175,29 @@ export const buildAsoHistoryChanges = (registro = {}) => {
       }
       return {
         campo: field.label,
-        de: field.key.toLowerCase().includes('data') ? formatDate(de) : normalizeCompareValue(de) || 'Nao informado',
-        para: field.key.toLowerCase().includes('data') ? formatDate(para) : normalizeCompareValue(para) || 'Nao informado',
+        de:
+          field.key.toLowerCase().includes('data')
+            ? formatDate(de)
+            : field.key.toLowerCase().includes('status')
+              ? resolveAsoStatusMeta(de).label
+              : normalizeCompareValue(de) || 'Nao informado',
+        para:
+          field.key.toLowerCase().includes('data')
+            ? formatDate(para)
+            : field.key.toLowerCase().includes('status')
+              ? resolveAsoStatusMeta(para).label
+              : normalizeCompareValue(para) || 'Nao informado',
       }
     })
     .filter(Boolean)
+}
+
+export const resolveAsoHistoryActionLabel = (acao = '') => {
+  const normalized = String(acao || '').trim().toLowerCase()
+  const map = {
+    edicao: 'Edicao',
+    registro_exame: 'Baixa de exame',
+    baixa_exame: 'Baixa de exame',
+  }
+  return map[normalized] || normalized || 'Acao nao informada'
 }

--- a/supabase/migrations/20260412_aso_baixa_e_historico.sql
+++ b/supabase/migrations/20260412_aso_baixa_e_historico.sql
@@ -1,0 +1,542 @@
+-- Ajusta o fluxo de baixa de ASO: fecha o registro atual, cria um novo ciclo
+-- e registra historico apenas para alteracoes reais.
+
+alter table public.aso_controle
+  add column if not exists status_registro text not null default 'ativo';
+
+alter table public.aso_controle
+  add column if not exists registro_origem_id uuid null references public.aso_controle(id) on delete set null;
+
+alter table public.aso_controle
+  add column if not exists baixado_em timestamptz null;
+
+alter table public.aso_controle
+  add column if not exists baixado_por uuid null references public.app_users(id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'aso_controle_status_registro_check'
+      and conrelid = 'public.aso_controle'::regclass
+  ) then
+    alter table public.aso_controle
+      add constraint aso_controle_status_registro_check
+      check (status_registro in ('ativo', 'baixado'));
+  end if;
+end
+$$;
+
+update public.aso_controle
+set status_registro = 'ativo'
+where status_registro is null;
+
+create index if not exists aso_controle_status_registro_idx
+  on public.aso_controle (status_registro);
+
+create index if not exists aso_controle_registro_origem_idx
+  on public.aso_controle (registro_origem_id);
+
+drop index if exists public.aso_controle_owner_pessoa_admissional_unique_idx;
+create unique index if not exists aso_controle_owner_pessoa_admissional_unique_idx
+  on public.aso_controle (account_owner_id, pessoa_id)
+  where tipo_exame_id = '11111111-1111-4111-8111-111111111111'
+    and status_registro = 'ativo';
+
+drop index if exists public.aso_controle_owner_pessoa_demissional_unique_idx;
+create unique index if not exists aso_controle_owner_pessoa_demissional_unique_idx
+  on public.aso_controle (account_owner_id, pessoa_id)
+  where tipo_exame_id = '33333333-3333-4333-8333-333333333333'
+    and status_registro = 'ativo';
+
+update public.aso_historico
+set acao = 'baixa_exame'
+where acao = 'registro_exame';
+
+alter table public.aso_historico
+  drop constraint if exists aso_historico_acao_check;
+
+alter table public.aso_historico
+  add constraint aso_historico_acao_check
+  check (acao in ('cadastro', 'edicao', 'baixa_exame'));
+
+create or replace view public.aso_controle_view as
+select
+  aso.id,
+  aso.pessoa_id,
+  pv.nome as funcionario,
+  pv.nome,
+  pv.matricula,
+  pv.centro_servico_id,
+  pv.centro_servico,
+  pv."centroServico",
+  pv.setor_id,
+  pv.setor,
+  pv.cargo_id,
+  pv.cargo,
+  aso.tipo_exame_id,
+  tipo.codigo as tipo_exame_codigo,
+  tipo.nome as tipo_exame,
+  aso.data_exame,
+  aso.proximo_vencimento,
+  case
+    when aso.status_registro = 'baixado' then null
+    when aso.proximo_vencimento is null then null
+    else (aso.proximo_vencimento - current_date)
+  end as dias_para_vencer,
+  case
+    when aso.status_registro = 'baixado' then 'baixado'
+    when tipo.codigo = 'demissional' then 'sem_renovacao'
+    when aso.proximo_vencimento is null then 'sem_vencimento'
+    when aso.proximo_vencimento < current_date then 'vencido'
+    when aso.proximo_vencimento = current_date then 'vence_hoje'
+    when aso.proximo_vencimento <= (current_date + 15) then 'vence_15'
+    when aso.proximo_vencimento <= (current_date + 30) then 'vence_30'
+    when aso.proximo_vencimento <= (current_date + 60) then 'vence_60'
+    else 'em_dia'
+  end as status_vencimento,
+  aso.observacao,
+  aso.usuario_cadastro,
+  coalesce(uc.username, uc.display_name, uc.email, aso.usuario_cadastro::text) as usuario_cadastro_nome,
+  aso.usuario_edicao,
+  coalesce(ue.username, ue.display_name, ue.email, aso.usuario_edicao::text) as usuario_edicao_nome,
+  aso.criado_em,
+  aso.atualizado_em,
+  aso.account_owner_id,
+  pv."dataDemissao" as data_demissao,
+  pv.ativo,
+  aso.status_registro,
+  aso.registro_origem_id,
+  aso.baixado_em,
+  aso.baixado_por
+from public.aso_controle aso
+join public.pessoas_view pv on pv.id = aso.pessoa_id
+join public.aso_tipos_exame tipo on tipo.id = aso.tipo_exame_id
+left join public.app_users uc on uc.id = aso.usuario_cadastro
+left join public.app_users ue on ue.id = aso.usuario_edicao;
+
+create or replace function public.rpc_aso_create_full(
+  p_pessoa_id uuid,
+  p_tipo_exame_id uuid,
+  p_data_exame date,
+  p_observacao text default null,
+  p_usuario_id uuid default null
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := public.is_master();
+  v_user uuid := case when v_is_master and p_usuario_id is not null then p_usuario_id else auth.uid() end;
+  v_row_owner uuid;
+  v_pessoa_ativo boolean;
+  v_pessoa_data_demissao timestamptz;
+  v_tipo_codigo text;
+  v_tipo_nome text;
+  v_id uuid;
+begin
+  if not v_is_master and not public.has_permission('pessoas.write'::text) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_owner is null and not v_is_master then
+    raise exception 'owner_not_resolved' using errcode = '42501';
+  end if;
+
+  select
+    p.account_owner_id,
+    p.ativo,
+    p."dataDemissao"
+    into
+      v_row_owner,
+      v_pessoa_ativo,
+      v_pessoa_data_demissao
+  from public.pessoas p
+  where p.id = p_pessoa_id;
+
+  if v_row_owner is null then
+    raise exception 'pessoa_not_found' using errcode = 'P0001';
+  end if;
+
+  if not v_is_master and v_row_owner <> v_owner then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  select
+    codigo,
+    nome
+  into
+    v_tipo_codigo,
+    v_tipo_nome
+  from public.aso_tipos_exame
+  where id = p_tipo_exame_id
+    and ativo = true;
+
+  if v_tipo_codigo is null then
+    raise exception 'tipo_exame_aso_not_found' using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from public.aso_controle aso
+    where aso.account_owner_id = v_row_owner
+      and aso.pessoa_id = p_pessoa_id
+      and aso.tipo_exame_id = p_tipo_exame_id
+      and aso.data_exame = p_data_exame
+  ) then
+    raise exception 'aso_duplicate'
+      using errcode = '23505',
+            message = 'Ja existe um ASO deste tipo para o funcionario informado na mesma data.';
+  end if;
+
+  if v_tipo_codigo in ('admissional', 'demissional')
+     and exists (
+       select 1
+       from public.aso_controle aso
+       where aso.account_owner_id = v_row_owner
+         and aso.pessoa_id = p_pessoa_id
+         and aso.tipo_exame_id = p_tipo_exame_id
+         and aso.status_registro = 'ativo'
+     ) then
+    raise exception 'aso_unique_tipo'
+      using errcode = '23505',
+            message = format('Ja existe um exame %s ativo para este funcionario.', lower(v_tipo_nome));
+  end if;
+
+  if v_tipo_codigo = 'demissional'
+     and coalesce(v_pessoa_ativo, true) = true
+     and v_pessoa_data_demissao is null then
+    raise exception 'aso_demissional_requires_inactive'
+      using errcode = '23514',
+            message = 'Exame demissional so pode ser cadastrado para funcionario inativo ou com data de desligamento.';
+  end if;
+
+  insert into public.aso_controle (
+    pessoa_id,
+    tipo_exame_id,
+    data_exame,
+    observacao,
+    usuario_cadastro,
+    account_owner_id,
+    status_registro
+  ) values (
+    p_pessoa_id,
+    p_tipo_exame_id,
+    p_data_exame,
+    p_observacao,
+    v_user,
+    v_row_owner,
+    'ativo'
+  )
+  returning id into v_id;
+
+  return query
+    select vw.*
+    from public.aso_controle_view vw
+    where vw.id = v_id
+      and (v_is_master or vw.account_owner_id = v_owner);
+end;
+$$;
+
+create or replace function public.rpc_aso_update_full(
+  p_id uuid,
+  p_tipo_exame_id uuid,
+  p_data_exame date,
+  p_observacao text default null,
+  p_usuario_id uuid default null,
+  p_acao text default 'edicao'
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := public.is_master();
+  v_user uuid := case when v_is_master and p_usuario_id is not null then p_usuario_id else auth.uid() end;
+  v_row_owner uuid;
+  v_pessoa_id uuid;
+  v_pessoa_ativo boolean;
+  v_pessoa_data_demissao timestamptz;
+  v_tipo_codigo text;
+  v_tipo_nome text;
+  v_before jsonb;
+  v_after jsonb;
+  v_acao text := case when p_acao = 'baixa_exame' then 'baixa_exame' else 'edicao' end;
+begin
+  if not v_is_master and not public.has_permission('pessoas.write'::text) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_owner is null and not v_is_master then
+    raise exception 'owner_not_resolved' using errcode = '42501';
+  end if;
+
+  select
+    aso.account_owner_id,
+    aso.pessoa_id,
+    p.ativo,
+    p."dataDemissao"
+  into
+    v_row_owner,
+    v_pessoa_id,
+    v_pessoa_ativo,
+    v_pessoa_data_demissao
+  from public.aso_controle aso
+  join public.pessoas p on p.id = aso.pessoa_id
+  where aso.id = p_id;
+
+  if v_row_owner is null then
+    raise exception 'aso_not_found' using errcode = 'P0001';
+  end if;
+
+  if not v_is_master and v_row_owner <> v_owner then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  select
+    codigo,
+    nome
+  into
+    v_tipo_codigo,
+    v_tipo_nome
+  from public.aso_tipos_exame
+  where id = p_tipo_exame_id
+    and ativo = true;
+
+  if v_tipo_codigo is null then
+    raise exception 'tipo_exame_aso_not_found' using errcode = '23503';
+  end if;
+
+  if exists (
+    select 1
+    from public.aso_controle aso
+    where aso.account_owner_id = v_row_owner
+      and aso.pessoa_id = v_pessoa_id
+      and aso.tipo_exame_id = p_tipo_exame_id
+      and aso.data_exame = p_data_exame
+      and aso.id <> p_id
+  ) then
+    raise exception 'aso_duplicate'
+      using errcode = '23505',
+            message = 'Ja existe um ASO deste tipo para o funcionario informado na mesma data.';
+  end if;
+
+  if v_tipo_codigo in ('admissional', 'demissional')
+     and exists (
+       select 1
+       from public.aso_controle aso
+       where aso.account_owner_id = v_row_owner
+         and aso.pessoa_id = v_pessoa_id
+         and aso.tipo_exame_id = p_tipo_exame_id
+         and aso.id <> p_id
+         and aso.status_registro = 'ativo'
+     ) then
+    raise exception 'aso_unique_tipo'
+      using errcode = '23505',
+            message = format('Ja existe um exame %s ativo para este funcionario.', lower(v_tipo_nome));
+  end if;
+
+  if v_tipo_codigo = 'demissional'
+     and coalesce(v_pessoa_ativo, true) = true
+     and v_pessoa_data_demissao is null then
+    raise exception 'aso_demissional_requires_inactive'
+      using errcode = '23514',
+            message = 'Exame demissional so pode ser cadastrado para funcionario inativo ou com data de desligamento.';
+  end if;
+
+  select to_jsonb(vw)
+    into v_before
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  update public.aso_controle
+     set tipo_exame_id = p_tipo_exame_id,
+         data_exame = p_data_exame,
+         observacao = p_observacao,
+         usuario_edicao = v_user,
+         atualizado_em = now()
+   where id = p_id;
+
+  select to_jsonb(vw)
+    into v_after
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  if coalesce(v_before, '{}'::jsonb) is distinct from coalesce(v_after, '{}'::jsonb) then
+    insert into public.aso_historico (
+      aso_id,
+      pessoa_id,
+      acao,
+      dados_antes,
+      dados_depois,
+      observacao,
+      usuario_responsavel,
+      account_owner_id
+    ) values (
+      p_id,
+      v_pessoa_id,
+      v_acao,
+      v_before,
+      coalesce(v_after, '{}'::jsonb),
+      p_observacao,
+      v_user,
+      v_row_owner
+    );
+  end if;
+
+  return query
+    select vw.*
+    from public.aso_controle_view vw
+    where vw.id = p_id
+      and (v_is_master or vw.account_owner_id = v_owner);
+end;
+$$;
+
+create or replace function public.rpc_aso_register_exam(
+  p_id uuid,
+  p_data_realizada date,
+  p_observacao text default null,
+  p_usuario_id uuid default null
+) returns setof public.aso_controle_view
+language plpgsql
+security definer
+set search_path = public, pg_temp
+set row_security = off
+as $$
+declare
+  v_owner uuid := public.current_account_owner_id();
+  v_is_master boolean := public.is_master();
+  v_user uuid := case when v_is_master and p_usuario_id is not null then p_usuario_id else auth.uid() end;
+  v_row_owner uuid;
+  v_pessoa_id uuid;
+  v_tipo_exame_id uuid;
+  v_tipo_codigo text;
+  v_observacao_atual text;
+  v_status_registro text;
+  v_before jsonb;
+  v_after jsonb;
+  v_new_id uuid;
+begin
+  if not v_is_master and not public.has_permission('pessoas.write'::text) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_owner is null and not v_is_master then
+    raise exception 'owner_not_resolved' using errcode = '42501';
+  end if;
+
+  select
+    aso.account_owner_id,
+    aso.pessoa_id,
+    aso.tipo_exame_id,
+    aso.observacao,
+    aso.status_registro,
+    tipo.codigo
+  into
+    v_row_owner,
+    v_pessoa_id,
+    v_tipo_exame_id,
+    v_observacao_atual,
+    v_status_registro,
+    v_tipo_codigo
+  from public.aso_controle aso
+  join public.aso_tipos_exame tipo on tipo.id = aso.tipo_exame_id
+  where aso.id = p_id;
+
+  if v_row_owner is null then
+    raise exception 'aso_not_found' using errcode = 'P0001';
+  end if;
+
+  if not v_is_master and v_row_owner <> v_owner then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if coalesce(v_status_registro, 'ativo') = 'baixado' then
+    raise exception 'aso_already_closed'
+      using errcode = '23514',
+            message = 'Este registro de ASO ja recebeu baixa.';
+  end if;
+
+  if v_tipo_codigo = 'demissional' then
+    raise exception 'aso_no_renewal'
+      using errcode = '23514',
+            message = 'Exame demissional nao possui renovacao.';
+  end if;
+
+  select to_jsonb(vw)
+    into v_before
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  update public.aso_controle
+     set status_registro = 'baixado',
+         baixado_em = now(),
+         baixado_por = v_user,
+         usuario_edicao = v_user,
+         atualizado_em = now()
+   where id = p_id;
+
+  select to_jsonb(vw)
+    into v_after
+  from public.aso_controle_view vw
+  where vw.id = p_id;
+
+  if coalesce(v_before, '{}'::jsonb) is distinct from coalesce(v_after, '{}'::jsonb) then
+    insert into public.aso_historico (
+      aso_id,
+      pessoa_id,
+      acao,
+      dados_antes,
+      dados_depois,
+      observacao,
+      usuario_responsavel,
+      account_owner_id
+    ) values (
+      p_id,
+      v_pessoa_id,
+      'baixa_exame',
+      v_before,
+      coalesce(v_after, '{}'::jsonb),
+      p_observacao,
+      v_user,
+      v_row_owner
+    );
+  end if;
+
+  insert into public.aso_controle (
+    pessoa_id,
+    tipo_exame_id,
+    data_exame,
+    observacao,
+    usuario_cadastro,
+    account_owner_id,
+    status_registro,
+    registro_origem_id
+  ) values (
+    v_pessoa_id,
+    v_tipo_exame_id,
+    p_data_realizada,
+    coalesce(p_observacao, v_observacao_atual),
+    v_user,
+    v_row_owner,
+    'ativo',
+    p_id
+  )
+  returning id into v_new_id;
+
+  return query
+    select vw.*
+    from public.aso_controle_view vw
+    where vw.id = v_new_id
+      and (v_is_master or vw.account_owner_id = v_owner);
+end;
+$$;
+
+comment on function public.rpc_aso_register_exam(uuid, date, text, uuid) is
+  'Da baixa no registro atual do ASO e cria um novo ciclo com a data realizada.';


### PR DESCRIPTION
- O que foi feito:
  - alterado o fluxo de "registrar exame" para baixa operacional do ASO
  - registro atual passa para status `baixado` e permanece na lista
  - nova linha e criada com a data realizada e novo proximo vencimento
  - historico da tela passa a exibir apenas alteracoes reais, ocultando `cadastro`
  - cores de 60/30/15 dias foram diferenciadas na legenda, chips e linhas
  - ajustadas regras de unicidade para admissional/demissional considerando apenas registro ativo
  - ajuda contextual e documentacao da tela ASO foram atualizadas

- Arquivos:
  - supabase/migrations/20260412_aso_baixa_e_historico.sql
  - api/_shared/operations.js
  - api/index.js
  - src/hooks/useAsoController.js
  - src/utils/asoUtils.js
  - src/components/Aso/AsoActions.jsx
  - src/components/Aso/AsoFilters.jsx
  - src/components/Aso/AsoHistoryTimeline.jsx
  - src/components/Aso/AsoImportModal.jsx
  - src/components/Aso/AsoRegisterExamModal.jsx
  - src/components/Aso/AsoTable.jsx
  - src/styles/AsoPage.css
  - src/help/helpAso.json
  - src/services/asoService.js
  - docs/ASO.txt
  - TASKS.md
  - README.md

- Mapeamento:
  - Tela Controle de ASO: baixa do exame substitui atualizacao direta do mesmo registro
  - Banco/RPCs: novo status de registro, baixa do registro atual e criacao do novo ciclo
  - Historico: remove exibicao de cadastro inicial e padroniza acao como baixa de exame
  - UI: renomeacao de botoes/modal e revisao de cores da legenda/status

- Como validar:
  - npm run build
  - aplicar migration 20260412_aso_baixa_e_historico.sql
  - validar baixa em registro admissional/periodico
  - confirmar que demissional continua sem renovacao
  - conferir historico sem eventos de cadastro inicial

- Impacto multi-tenant:
  - sem alteracao de escopo entre tenants
  - owner scope e RLS permanecem baseados em `account_owner_id` e `pessoas.read/write`

- Docs:
  - docs/ASO.txt atualizado