### PR TITLE
fix(relatorios): consultar materiais em lotes nos relatorios automaticos

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -51,8 +51,17 @@
 - Validar no app que "Cadastrado por"/"Registrado por" mostra o dependente nas telas Pessoas, Materiais, Saidas e Cadastro Base.
 - Validar no app que Acidentes continua exibindo o dependente em "Registrado por" e que HHT mensal permanece consistente no historico/listagem.
 - Revisar o limite global de emails do Supabase Auth (`Auth -> Rate limits -> Rate limit for sending emails`).
+- Validar em producao o ultimo `inventory_report` semanal/mensal por `account_owner_id`, conferindo `metadados->>tipo`, `email_status`, `email_enviado_em`, `email_erro` e `email_tentativas`.
+- Validar em producao quais usuarios entram como destinatarios por owner nas funcoes de email (`credential` admin/master, `parent_user_id`, `email` e `ativo`).
+- Validar em producao a geracao `relatorio-estoque-semanal` apos 2026-03-06 para o owner `59191387-669b-4585-8e11-7070d9769d86`, pois o log Brevo mostra semanal enviado para Fabiana em 2026-03-06 e depois apenas relatorio de troca de EPI.
+- Publicar/deploy das Edge Functions `relatorio-estoque-semanal` e `relatorio-estoque-mensal` com busca de `materiais_view` em lotes.
+- Reexecutar/validar os crons `relatorio-estoque-semanal` e `relatorio-estoque-mensal` em producao para confirmar que nao ocorre mais erro HTTP/2 em `materiais_view?id=in.(...)`.
+- Validar que o owner `59191387-669b-4585-8e11-7070d9769d86` volta a criar `inventory_report` semanal/mensal pendente e que o job de email envia para `fabiana.gomes@faa.edu.br`.
 
 ## Observacoes
 - `git status` no sandbox exige `safe.directory` por causa do ownership do workspace.
 - Existem alteracoes locais previas em `src/pages/Configuracoes.jsx`, `src/config/permissions.js`, `docs/Configuracoes.txt` e `docs/PermissoesToggles.txt` que continuam sendo usadas.
 - O item `TESTE` foi reproduzido por SQL em `rpc_catalog_list('centros_estoque')` e `rpc_catalog_list('centros_servico')` com sessao simulada de dependente.
+- Auditoria local dos relatorios automaticos: as Edge Functions de geracao semanal/mensal/troca percorrem todos os owners ativos; logs de producao informados em 2026-04-18 mostram `test=false` no cron semanal, mensal e troca. Proxima suspeita: relatorios de outros owners ja marcados como enviados/erro ou usuarios fora do filtro de destinatarios.
+- CSV Brevo `logs-10552678-1776523890567.csv`: semanal foi enviado para `fabiana.gomes@faa.edu.br` em 2026-03-06; depois os semanais do CSV aparecem somente para `toka.fgg@gmail.com`, enquanto troca de EPI continua indo para Fabiana.
+- Diagnostico 2026-04-18: o motivo provavel da ausencia dos relatorios semanais/mensais da Fabiana nao e o dependente gravar movimentacao; a geracao falha ao listar muitos materiais em `materiais_view` por uma URL PostgREST gigante. O codigo filtra movimentacoes por `account_owner_id`, entao dependentes do mesmo owner devem entrar no relatorio.

--- a/docs/RelatorioEstoque.txt
+++ b/docs/RelatorioEstoque.txt
@@ -129,6 +129,22 @@ Atualizacao 2026-02 (semanal)
 - `supabase/functions/relatorio-estoque-semanal-email/_shared/relatorioEstoqueSemanalEmailCore.ts`
 - `supabase/functions/cleanup-import-errors/index.ts`
 
+Atualizacao 2026-04
+-------------------
+- Geracao semanal e mensal passou a buscar `materiais_view` em lotes de 50 IDs.
+- A mudanca evita URL gigante em PostgREST (`id=in.(...)`) quando o tenant tem muitos materiais.
+- Diagnostico: logs de cron em 2026-03 e 2026-04 falhavam em `Falha ao listar materiais` com erro HTTP/2 na chamada de `materiais_view`.
+- O filtro de tenant permanece em `materiais.account_owner_id`; a view recebe somente IDs do owner atual.
+- Relatorios de dependentes continuam entrando quando as movimentacoes foram gravadas no mesmo `account_owner_id` do owner.
+- Antes/Depois:
+- Antes: um tenant com muitos materiais podia abortar a geracao semanal/mensal antes de criar novo `inventory_report`.
+- Depois: a consulta de materiais e particionada, reduzindo o tamanho das requisicoes e permitindo gerar novos relatorios.
+- Arquivos alterados:
+- `supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts`
+- `supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts`
+- `docs/RelatorioEstoque.txt`
+- `TASKS.md`
+
 ===========================================
 Mapa de Codigo (funcoes, hooks e constantes)
 ===========================================
@@ -162,6 +178,10 @@ Funcoes principais
   - Caminho: supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
   - Responsavel por: montar dados e persistir em inventory_report.
   - Calcula ranking de consumo, desvios e cobertura por centro/setor.
+- relatorioEstoqueSemanalCore
+  - Tipo: utilitario de edge function
+  - Caminho: supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
+  - Responsavel por: montar CSVs semanais, carregar materiais em lotes e persistir anexos em inventory_report.
 
 Constantes e configuracoes
 --------------------------
@@ -169,6 +189,11 @@ Constantes e configuracoes
   - Tipo: configuracao
   - Caminho: src/config/RelatorioEstoqueConfig.js
   - Uso: limite mensal de geracao de PDF por relatorio.
+- MATERIAIS_VIEW_BATCH_SIZE
+  - Tipo: constante de Edge Function
+  - Caminho: supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
+  - Caminho: supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
+  - Uso: tamanho do lote para consultar `materiais_view` sem montar URL longa.
 
 Funcoes utilitarias relacionadas
 --------------------------------
@@ -176,6 +201,11 @@ Funcoes utilitarias relacionadas
   - Tipo: utilitario
   - Caminho: src/utils/RelatorioEstoquePdfUtils.js
   - Responsavel por: enviar HTML para renderizacao e baixar PDF.
+- carregarMateriaisPorOwner
+  - Tipo: utilitario de Edge Function
+  - Caminho: supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
+  - Caminho: supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
+  - Responsavel por: buscar materiais do owner e consultar `materiais_view` em lotes.
 
 Servicos e integracoes externas
 -------------------------------

--- a/supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
+++ b/supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
@@ -8,6 +8,7 @@ const CENTRO_ESTOQUE_TABLE = "centros_estoque"
 const supabaseUrl = Deno.env.get("SUPABASE_URL") || ""
 const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
 const materiaisView = Deno.env.get("MATERIAIS_VIEW") || DEFAULT_MATERIAIS_VIEW
+const MATERIAIS_VIEW_BATCH_SIZE = 50
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
   auth: { persistSession: false },
@@ -1005,6 +1006,16 @@ const execute = async (builder: Promise<{ data: any; error: any }>, fallbackMess
   }
   return data
 }
+
+const chunkArray = (items: any[] = [], size = MATERIAIS_VIEW_BATCH_SIZE) => {
+  const chunks: any[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const sortByNome = (a: any, b: any) => trim(a?.nome ?? "").localeCompare(trim(b?.nome ?? ""))
 
 const executeSingle = async (builder: any, fallbackMessage: string) => {
   const { data, error } = await builder.single()
@@ -2042,11 +2053,15 @@ const carregarMateriaisPorOwner = async (ownerId: string) => {
   if (!ids.length) {
     return []
   }
-  const materiaisRegistros = await execute(
-    supabaseAdmin.from(materiaisView).select("*").in("id", ids).order("nome"),
-    "Falha ao listar materiais.",
-  )
-  return (materiaisRegistros ?? []).map((item: any) => mapMaterialRecord(item))
+  const materiaisRegistros: any[] = []
+  for (const idsLote of chunkArray(ids)) {
+    const lote = await execute(
+      supabaseAdmin.from(materiaisView).select("*").in("id", idsLote).order("nome"),
+      "Falha ao listar materiais.",
+    )
+    materiaisRegistros.push(...(lote ?? []))
+  }
+  return materiaisRegistros.sort(sortByNome).map((item: any) => mapMaterialRecord(item))
 }
 
 const preencherCentrosEstoque = async (registros: any[] = [], ownerId: string) => {

--- a/supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
+++ b/supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
@@ -12,6 +12,7 @@ const WEEK_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 const supabaseUrl = Deno.env.get("SUPABASE_URL") || ""
 const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
 const materiaisView = Deno.env.get("MATERIAIS_VIEW") || DEFAULT_MATERIAIS_VIEW
+const MATERIAIS_VIEW_BATCH_SIZE = 50
 
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
   auth: { persistSession: false },
@@ -175,6 +176,16 @@ const execute = async (builder: any, fallbackMessage: string) => {
   }
   return data
 }
+
+const chunkArray = (items: any[] = [], size = MATERIAIS_VIEW_BATCH_SIZE) => {
+  const chunks: any[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+const sortByNome = (a: any, b: any) => trim(a?.nome ?? "").localeCompare(trim(b?.nome ?? ""))
 
 const executeSingle = async (builder: any, fallbackMessage: string) => {
   const { data, error } = await builder.single()
@@ -407,11 +418,15 @@ const carregarMateriaisPorOwner = async (ownerId: string) => {
   if (!ids.length) {
     return []
   }
-  const materiaisRegistros = await execute(
-    supabaseAdmin.from(materiaisView).select("*").in("id", ids).order("nome"),
-    "Falha ao listar materiais.",
-  )
-  return materiaisRegistros ?? []
+  const materiaisRegistros: any[] = []
+  for (const idsLote of chunkArray(ids)) {
+    const lote = await execute(
+      supabaseAdmin.from(materiaisView).select("*").in("id", idsLote).order("nome"),
+      "Falha ao listar materiais.",
+    )
+    materiaisRegistros.push(...(lote ?? []))
+  }
+  return materiaisRegistros.sort(sortByNome)
 }
 
 const carregarCentrosEstoqueMap = async (ownerId: string, ids: string[]) => {


### PR DESCRIPTION
O que foi feito:
- Quebra a consulta de materiais_view em lotes de 50 IDs no relatorio semanal.
- Aplica a mesma correcao no relatorio mensal.
- Mantem o escopo multi-tenant pela lista de IDs filtrada em materiais.account_owner_id.
- Documenta o diagnostico do erro HTTP/2 causado por URL PostgREST gigante.
- Atualiza TASKS.md com deploy e validacoes pendentes.

Arquivos:
- supabase/functions/relatorio-estoque-semanal/_shared/relatorioEstoqueSemanalCore.ts
- supabase/functions/relatorio-estoque-mensal/_shared/relatorioEstoqueCore.ts
- docs/RelatorioEstoque.txt
- TASKS.md

Mapeamento:
- Relatorio de Estoque: geracao semanal/mensal deixa de consultar todos os materiais em uma unica URL.
- Edge Functions: carregarMateriaisPorOwner passa a consultar materiais_view em lotes.
- Documentacao: registra causa, antes/depois e validacao.

Como validar:
- Deploy das functions relatorio-estoque-semanal e relatorio-estoque-mensal.
- Reexecutar a geracao semanal/mensal em producao.
- Confirmar ausencia do erro HTTP/2 em materiais_view.
- Confirmar inventory_report pendente para Fabiana e envio pelo job de email.

Multi-tenant:
- Sem alteracao de schema/RLS.
- O filtro de tenant permanece em materiais.account_owner_id antes da consulta da view.

Docs:
- docs/RelatorioEstoque.txt atualizado.
- TASKS.md atualizado.