### PR TITLE
feat(analise-estoque): adicionar auditoria real do forecast e compra …

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,7 @@ supabase/
     20260418_04_aso_rpc_register_exam_next.sql  # migration SQL
     20260418_aso_mudanca_funcao_e_baixa_com_tipo.sql  # migration SQL
     20260423_fix_forecast_snapshot_versioning.sql  # migration SQL
+    20260423_add_forecast_audit_and_purchase_rpcs.sql  # migration SQL
   migrations_rebuild/
     0001_extensions.sql  # migration rebuild SQL
     0002_tables.sql  # migration rebuild SQL

--- a/TASKS.md
+++ b/TASKS.md
@@ -35,12 +35,14 @@
 - Ajuda contextual e documentacao da tela `Analise de Estoque` foram atualizadas para refletir as abas e os novos blocos de leitura do forecast.
 - Snapshot de forecast passou a preservar as linhas mensais por `inventory_forecast_id`, evitando que um forecast novo sobrescreva a previsao mensal de um snapshot antigo.
 - API de forecast (`api/_shared/operations.js`) passou a ler a serie mensal pelo `forecast_id` selecionado/derivado do resumo.
+- Tela `Analise de Estoque` passou a consumir auditoria real do snapshot (`previsto x realizado`, WAPE/MAPE, vies) e RPC de compra sugerida por estoque/minimo/cobertura.
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260412_add_aso_page_permissions.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260412_aso_baixa_e_historico.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260423_fix_forecast_snapshot_versioning.sql` no projeto Supabase.
+- Aplicar a migration `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql` no projeto Supabase.
 - Aplicar no projeto Supabase, nesta ordem:
   - `supabase/migrations/20260418_01_aso_mudanca_funcao_schema.sql`
   - `supabase/migrations/20260418_02_aso_rpc_create_full.sql`
@@ -78,3 +80,4 @@
 - Diagnostico 2026-04-18: o motivo provavel da ausencia dos relatorios semanais/mensais da Fabiana nao e o dependente gravar movimentacao; a geracao falha ao listar muitos materiais em `materiais_view` por uma URL PostgREST gigante. O codigo filtra movimentacoes por `account_owner_id`, entao dependentes do mesmo owner devem entrar no relatorio.
 - Forecast 2026-04-23: a separacao em abas no front e apenas organizacional; a regra do RPC rolling e a persistencia dos snapshots continuam iguais no backend.
 - Forecast 2026-04-23: a persistencia do snapshot agora e versionada por `inventory_forecast_id`, mas o rolling aberto continua atualizando o mesmo `inventory_forecast` enquanto `qtd_meses_base < 12`.
+- Forecast 2026-04-23: a auditoria do snapshot mede qualidade do forecast em meses ja realizados; o diagnostico estatistico continua sendo uma leitura complementar da distribuicao historica mensal.

--- a/docs/AnaliseEstoque.txt
+++ b/docs/AnaliseEstoque.txt
@@ -72,8 +72,8 @@ Boas praticas
 - Previsao considera entradas, saidas e saldo anual no card e no grafico.
 - Previsao de entrada usa media movel 3m de entrada e fator sazonal de entrada.
 - Aba Operacional concentra o rolling atual e o grafico expandido.
-- Aba Compra usa os dados atuais de risco operacional e estoque minimo para destacar compra imediata, reposicao planejada, cobertura curta e excesso/baixo giro.
-- Aba Auditoria concentra o snapshot selecionado e os atalhos para validacao e diagnostico.
+- Aba Compra agora prioriza o RPC de compra sugerida, combinando estoque atual, estoque minimo, consumo recente e cobertura.
+- Aba Auditoria concentra o snapshot selecionado, previsto x realizado por mes e os atalhos para validacao e diagnostico.
 - Diagnostico usa agg_gasto_mensal (valor_saida) como base estatistica.
 - Respeitar `account_owner_id` em todas as consultas (multi-tenant).
 
@@ -155,6 +155,26 @@ Atualizacao 2026-04 (snapshot)
 - Antes: `f_previsao_gasto_mensal` era unica por owner + mes + cenario, e snapshots novos podiam sobrescrever snapshots antigos.
 - Depois: o snapshot fechado fica preservado por `inventory_forecast_id`, e a auditoria consegue ler a previsao mensal da versao correta.
 
+Atualizacao 2026-04 (auditoria e compra)
+----------------------------------------
+- Migration `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql` criada com dois RPCs novos:
+  - `rpc_previsao_gasto_mensal_auditar(p_owner_id, p_forecast_id)` para comparar previsto x realizado por snapshot.
+  - `rpc_previsao_compra_sugerida(p_owner_id, p_forecast_id)` para calcular compra sugerida por estoque atual, minimo e cobertura.
+- A aba `Auditoria` passou a consumir a auditoria real do snapshot selecionado, com meses auditados, viés, WAPE/MAPE e tabela mensal previsto x realizado.
+- A aba `Compra` passou a priorizar o payload do RPC de compra; se o RPC nao estiver disponivel, o front ainda cai no fallback local anterior.
+- `diagnosticar_estatisticas_mensais` continua existindo para leitura estatistica historica; ele nao foi substituido pela auditoria do snapshot.
+- Arquivos alterados:
+- `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql`
+- `src/pages/AnaliseEstoquePage.jsx`
+- `src/styles/DashboardPage.css`
+- `src/help/helpAnaliseEstoque.json`
+- `docs/AnaliseEstoque.txt`
+- Antes/Depois:
+- Antes: a aba `Auditoria` mostrava apenas resumo do snapshot e abria modais de validacao/diagnostico.
+- Depois: a aba `Auditoria` mostra acuracia do snapshot e comparacao mensal entre previsto e realizado.
+- Antes: a aba `Compra` usava somente heuristica derivada no client.
+- Depois: a aba `Compra` prioriza uma recomendacao calculada no banco por tenant e por snapshot.
+
 ===========================================
 Mapa de Codigo (funcoes, hooks e constantes)
 ===========================================
@@ -218,6 +238,10 @@ Servicos e integracoes externas
   - Tipo: SQL (Supabase)
   - Caminho: supabase/migrations/20260423_fix_forecast_snapshot_versioning.sql
   - Responsavel por: preservar previsoes mensais por `inventory_forecast_id` e evitar sobrescrita entre snapshots.
+- Migration de auditoria e compra do forecast
+  - Tipo: SQL (Supabase)
+  - Caminho: supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
+  - Responsavel por: calcular auditoria previsto x realizado e planejamento de compra por snapshot.
 - Edge Function forecast-gasto-mensal
   - Tipo: Supabase Edge Function
   - Caminho: supabase/functions/forecast-gasto-mensal/index.ts

--- a/src/help/helpAnaliseEstoque.json
+++ b/src/help/helpAnaliseEstoque.json
@@ -32,8 +32,8 @@
       "A previsao rolling nao usa filtros de periodo: considera sempre os ultimos 12 meses completos.",
       "O periodo exibido pode ser selecionado no combo com historicos gerados.",
       "A aba Operacional concentra o rolling 12 meses com historico, saida prevista, entrada prevista e saldo.",
-      "A aba Compra resume itens abaixo do minimo, compra imediata, cobertura curta e excesso/baixo giro.",
-      "A aba Auditoria centraliza o snapshot selecionado e os atalhos de Validacao e Diagnostico.",
+      "A aba Compra prioriza a recomendacao do RPC de compra, calculada por estoque atual, estoque minimo, consumo recente e cobertura.",
+      "A aba Auditoria centraliza o snapshot selecionado, mostra previsto x realizado por mes e mantem os atalhos de Validacao e Diagnostico.",
       "O botao Validacao da previsao mostra as tabelas de gasto mensal e previsao mensal.",
       "O botao Diagnostico abre um modal com estatisticas mensais (mediana, P75, P90).",
       "Cron pode usar body {\"force\": true} para rodar fora do ultimo dia do mes.",
@@ -43,7 +43,8 @@
       "Previsao de entrada usa media movel 3m de entrada e fator sazonal de entrada.",
       "Tooltip da previsao mostra contingencia (P75), P90, mediana e alerta de volatilidade (CV > 1) calculados no RPC.",
       "Previsao inclui entradas e saidas, com saldo anual no card.",
-      "Diagnostico usa agg_gasto_mensal (valor_saida) para estatisticas mensais."
+      "Diagnostico usa agg_gasto_mensal (valor_saida) para estatisticas mensais.",
+      "Acuracia da auditoria usa WAPE/MAPE sobre os meses do snapshot que ja possuem realizado."
       ]
     }
 }

--- a/src/pages/AnaliseEstoquePage.jsx
+++ b/src/pages/AnaliseEstoquePage.jsx
@@ -556,6 +556,12 @@ export function AnaliseEstoquePage() {
   const [diagnosticoRows, setDiagnosticoRows] = useState([])
   const [diagnosticoPage, setDiagnosticoPage] = useState(1)
   const [diagnosticoCopied, setDiagnosticoCopied] = useState(false)
+  const [forecastAuditPayload, setForecastAuditPayload] = useState(null)
+  const [forecastAuditLoading, setForecastAuditLoading] = useState(false)
+  const [forecastAuditError, setForecastAuditError] = useState(null)
+  const [forecastCompraPayload, setForecastCompraPayload] = useState(null)
+  const [forecastCompraLoading, setForecastCompraLoading] = useState(false)
+  const [forecastCompraError, setForecastCompraError] = useState(null)
 
   const formatLabelFromDate = (value) => {
     const date = value instanceof Date ? value : new Date(value)
@@ -1052,8 +1058,113 @@ export function AnaliseEstoquePage() {
     forecastBase?.periodo_base_fim,
   )
   const forecastCreatedAtLabel = formatForecastTimestamp(forecastBase?.created_at)
+  const selectedForecastId = forecastBase?.id || null
+
+  useEffect(() => {
+    const shouldUseSupabase = !isLocalMode && isSupabaseConfigured() && supabase && profile?.owner_id
+    if (!shouldUseSupabase || !selectedForecastId) {
+      setForecastAuditPayload(null)
+      setForecastAuditError(null)
+      setForecastAuditLoading(false)
+      setForecastCompraPayload(null)
+      setForecastCompraError(null)
+      setForecastCompraLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const loadSupportData = async () => {
+      setForecastAuditLoading(true)
+      setForecastCompraLoading(true)
+      setForecastAuditError(null)
+      setForecastCompraError(null)
+
+      const [auditResult, compraResult] = await Promise.allSettled([
+        supabase.rpc('rpc_previsao_gasto_mensal_auditar', {
+          p_owner_id: profile.owner_id,
+          p_forecast_id: selectedForecastId,
+        }),
+        supabase.rpc('rpc_previsao_compra_sugerida', {
+          p_owner_id: profile.owner_id,
+          p_forecast_id: selectedForecastId,
+        }),
+      ])
+
+      if (cancelled) {
+        return
+      }
+
+      if (auditResult.status === 'fulfilled') {
+        if (auditResult.value.error) {
+          setForecastAuditError(auditResult.value.error.message || 'Erro ao carregar auditoria do snapshot.')
+          setForecastAuditPayload(null)
+        } else {
+          setForecastAuditPayload(auditResult.value.data || null)
+        }
+      } else {
+        setForecastAuditError(auditResult.reason?.message || 'Erro ao carregar auditoria do snapshot.')
+        setForecastAuditPayload(null)
+      }
+
+      if (compraResult.status === 'fulfilled') {
+        if (compraResult.value.error) {
+          setForecastCompraError(compraResult.value.error.message || 'Erro ao carregar planejamento de compra.')
+          setForecastCompraPayload(null)
+        } else {
+          setForecastCompraPayload(compraResult.value.data || null)
+        }
+      } else {
+        setForecastCompraError(compraResult.reason?.message || 'Erro ao carregar planejamento de compra.')
+        setForecastCompraPayload(null)
+      }
+
+      setForecastAuditLoading(false)
+      setForecastCompraLoading(false)
+    }
+
+    loadSupportData()
+
+    return () => {
+      cancelled = true
+    }
+  }, [profile?.owner_id, selectedForecastId])
 
   const compraInsights = useMemo(() => {
+    if (forecastCompraPayload?.status === 'ok') {
+      const resumo = forecastCompraPayload?.resumo || {}
+      return {
+        materiaisMonitorados: Number(resumo.materiais_monitorados || 0),
+        itensAbaixoMinimo: Number(resumo.itens_abaixo_minimo || 0),
+        itensCompraImediata: Number(resumo.itens_compra_imediata || 0),
+        itensReposicaoPlanejada: Number(resumo.itens_reposicao_planejada || 0),
+        itensCoberturaCurta: Number(resumo.itens_cobertura_curta || 0),
+        itensExcesso: Number(resumo.itens_excesso || 0),
+        valorCompraMinima: Number(resumo.valor_compra_minima || 0),
+        quantidadeCompraMinima: Number(resumo.quantidade_compra_minima || 0),
+        valorCompraSugerida: Number(resumo.valor_compra_sugerida || 0),
+        quantidadeCompraSugerida: Number(resumo.quantidade_compra_sugerida || 0),
+        coberturaMediaMeses:
+          resumo.cobertura_media_meses !== null && resumo.cobertura_media_meses !== undefined
+            ? Number(resumo.cobertura_media_meses)
+            : null,
+        saidaMediaMensalPrevista: Number(resumo.saida_media_mensal_prevista || 0),
+        entradaMediaMensalPrevista: Number(resumo.entrada_media_mensal_prevista || 0),
+        saldoAnualPrevisto: Number(resumo.saldo_anual_previsto || 0),
+        compraImediata: Array.isArray(forecastCompraPayload?.compra_imediata) ? forecastCompraPayload.compra_imediata : [],
+        reposicaoPlanejada: Array.isArray(forecastCompraPayload?.reposicao_planejada)
+          ? forecastCompraPayload.reposicao_planejada
+          : [],
+        excessoOuBaixoGiro: Array.isArray(forecastCompraPayload?.excesso_ou_baixo_giro)
+          ? forecastCompraPayload.excesso_ou_baixo_giro
+          : [],
+        semCoberturaCurta: Array.isArray(forecastCompraPayload?.cobertura_curta)
+          ? forecastCompraPayload.cobertura_curta
+          : [],
+        origem: 'rpc',
+      }
+    }
+
     const riscoList = Array.isArray(riscoOperacional) ? riscoOperacional : []
     const materiaisMonitorados = Array.isArray(estoqueBase?.itens) ? estoqueBase.itens.length : riscoList.length
     const deficitItems = riscoList
@@ -1109,14 +1220,34 @@ export function AnaliseEstoquePage() {
       materiaisMonitorados,
       itensAbaixoMinimo: deficitItems.length,
       itensCompraImediata: compraImediata.length,
+      itensReposicaoPlanejada: reposicaoPlanejada.length,
+      itensCoberturaCurta: semCoberturaCurta.length,
+      itensExcesso: excessoOuBaixoGiro.length,
       valorCompraMinima,
       quantidadeCompraMinima,
+      valorCompraSugerida: valorCompraMinima,
+      quantidadeCompraSugerida: quantidadeCompraMinima,
+      coberturaMediaMeses:
+        semCoberturaCurta.length > 0
+          ? semCoberturaCurta.reduce((acc, item) => acc + Number(item.coberturaMeses || 0), 0) /
+            Math.max(1, semCoberturaCurta.length)
+          : null,
+      saidaMediaMensalPrevista: previsaoSaidaTotal / 12,
+      entradaMediaMensalPrevista: previsaoEntradaTotal / 12,
+      saldoAnualPrevisto: previsaoSaldoTotal,
       compraImediata: compraImediata.slice(0, 5),
       reposicaoPlanejada: reposicaoPlanejada.slice(0, 5),
       excessoOuBaixoGiro: excessoOuBaixoGiro.slice(0, 5),
       semCoberturaCurta: semCoberturaCurta.slice(0, 5),
+      origem: 'fallback',
     }
-  }, [estoqueBase, riscoOperacional])
+  }, [estoqueBase, forecastCompraPayload, previsaoEntradaTotal, previsaoSaidaTotal, previsaoSaldoTotal, riscoOperacional])
+
+  const auditResumo = forecastAuditPayload?.resumo || null
+  const auditSerie = useMemo(
+    () => (Array.isArray(forecastAuditPayload?.serie) ? forecastAuditPayload.serie : []),
+    [forecastAuditPayload?.serie],
+  )
 
   const auditCards = useMemo(
     () => [
@@ -1128,31 +1259,37 @@ export function AnaliseEstoquePage() {
         tone: 'slate',
       },
       {
-        id: 'confianca',
-        title: 'Base e confianca',
+        id: 'base',
+        title: 'Base e metodo',
         value: `${formatNumber(forecastBase?.qtd_meses_base || 0)} meses`,
-        helper: `Nivel: ${forecastBase?.nivel_confianca || 'nao informado'}`,
+        helper: `${forecastBase?.metodo_previsao || '-'} | confianca ${forecastBase?.nivel_confianca || 'nao informada'}`,
         tone: 'blue',
       },
       {
-        id: 'metodo',
-        title: 'Metodo e tendencia',
-        value: forecastBase?.metodo_previsao || '-',
-        helper: `${forecastBase?.tipo_tendencia || 'sem tipo'} | fator ${formatNumber(
-          forecastBase?.fator_tendencia || 1,
-          2,
-        )}`,
+        id: 'auditados',
+        title: 'Meses auditados',
+        value: `${formatNumber(auditResumo?.meses_realizados || 0)} / ${formatNumber(auditResumo?.meses_total || 0)}`,
+        helper: `${formatNumber(auditResumo?.meses_pendentes || 0)} pendentes | tendencia ${forecastBase?.tipo_tendencia || 'sem tipo'}`,
         tone: 'green',
       },
       {
-        id: 'variacao',
-        title: 'Variacao vs base anterior',
-        value: formatPercent(forecastBase?.variacao_percentual || 0, 2),
-        helper: `Gasto ano anterior: ${formatCurrency(forecastBase?.gasto_ano_anterior || 0)}`,
+        id: 'acuracia',
+        title: 'Acuracia do snapshot',
+        value: `${formatNumber(auditResumo?.acuracia_wape || 0, 1)}%`,
+        helper: `WAPE ${formatNumber(auditResumo?.wape_percentual || 0, 1)}% | MAPE ${formatNumber(auditResumo?.mape_percentual || 0, 1)}%`,
+        tone: 'orange',
+      },
+      {
+        id: 'vies',
+        title: 'Vies do forecast',
+        value: formatPercent(auditResumo?.vies_percentual || 0, 2),
+        helper: `Previsto ${formatCurrency(auditResumo?.total_previsto_realizado || 0)} | Realizado ${formatCurrency(
+          auditResumo?.total_realizado || 0,
+        )}`,
         tone: 'orange',
       },
     ],
-    [forecastBase, forecastCreatedAtLabel, forecastPeriodoLabel],
+    [auditResumo, forecastBase, forecastCreatedAtLabel, forecastPeriodoLabel],
   )
 
   const buildForecastHistoricoClipboardText = () => {
@@ -1398,19 +1535,23 @@ export function AnaliseEstoquePage() {
               <div className="analysis-forecast-card">
                 <p className="analysis-forecast-label">Planejamento de compra</p>
                 <p className="analysis-forecast-value">
-                  {formatNumber(compraInsights.quantidadeCompraMinima)} un /{' '}
-                  {formatCurrency(compraInsights.valorCompraMinima)}
+                  {formatNumber(compraInsights.quantidadeCompraSugerida || compraInsights.quantidadeCompraMinima)} un /{' '}
+                  {formatCurrency(compraInsights.valorCompraSugerida || compraInsights.valorCompraMinima)}
                 </p>
                 <p className="analysis-forecast-subtitle">
-                  Reposicao minima sugerida com base em estoque atual, risco e consumo recente.
+                  Reposicao sugerida por estoque atual, minimo configurado e cobertura recente.
                 </p>
                 <div className="analysis-forecast-meta">
                   <span>Itens monitorados: {formatNumber(compraInsights.materiaisMonitorados)}</span>
                   <span>Itens abaixo do minimo: {formatNumber(compraInsights.itensAbaixoMinimo)}</span>
                   <span>Compra imediata: {formatNumber(compraInsights.itensCompraImediata)}</span>
-                  <span>Saida prevista media/mês: {formatCurrency(previsaoSaidaTotal / 12)}</span>
-                  <span>Entrada prevista media/mês: {formatCurrency(previsaoEntradaTotal / 12)}</span>
-                  <span>Saldo anual previsto: {formatCurrency(previsaoSaldoTotal)}</span>
+                  <span>Reposicao planejada: {formatNumber(compraInsights.itensReposicaoPlanejada || 0)}</span>
+                  <span>Cobertura media: {formatNumber(compraInsights.coberturaMediaMeses || 0, 1)} meses</span>
+                  <span>Saida prevista media/mês: {formatCurrency(compraInsights.saidaMediaMensalPrevista || 0)}</span>
+                  <span>Entrada prevista media/mês: {formatCurrency(compraInsights.entradaMediaMensalPrevista || 0)}</span>
+                  <span>Saldo anual previsto: {formatCurrency(compraInsights.saldoAnualPrevisto || 0)}</span>
+                  {forecastCompraLoading ? <span>Atualizando recomendacao de compra...</span> : null}
+                  {forecastCompraError && compraInsights.origem !== 'rpc' ? <span>{forecastCompraError}</span> : null}
                   {forecastStatusMessage ? <span>{forecastStatusMessage}</span> : null}
                 </div>
                 <div className="analysis-forecast-actions">
@@ -1441,7 +1582,7 @@ export function AnaliseEstoquePage() {
                   </span>
                 </header>
                 <strong className="dashboard-insight-card__value">{formatNumber(compraInsights.itensCompraImediata)}</strong>
-                <span className="dashboard-insight-card__helper">Itens com risco A e estoque abaixo do minimo.</span>
+                <span className="dashboard-insight-card__helper">Itens abaixo do minimo ou com cobertura menor que 1 mes.</span>
               </article>
               <article className="dashboard-insight-card dashboard-insight-card--blue">
                 <header className="dashboard-insight-card__header">
@@ -1450,7 +1591,9 @@ export function AnaliseEstoquePage() {
                     <StockIcon size={22} />
                   </span>
                 </header>
-                <strong className="dashboard-insight-card__value">{formatCurrency(compraInsights.valorCompraMinima)}</strong>
+                <strong className="dashboard-insight-card__value">
+                  {formatCurrency(compraInsights.valorCompraMinima)}
+                </strong>
                 <span className="dashboard-insight-card__helper">
                   {formatNumber(compraInsights.quantidadeCompraMinima)} unidades para voltar ao minimo.
                 </span>
@@ -1462,8 +1605,10 @@ export function AnaliseEstoquePage() {
                     <RevenueIcon size={22} />
                   </span>
                 </header>
-                <strong className="dashboard-insight-card__value">{formatCurrency(previsaoEntradaTotal / 12)}</strong>
-                <span className="dashboard-insight-card__helper">Media mensal de entrada no rolling selecionado.</span>
+                <strong className="dashboard-insight-card__value">
+                  {formatCurrency(compraInsights.entradaMediaMensalPrevista || 0)}
+                </strong>
+                <span className="dashboard-insight-card__helper">Media mensal de entrada do snapshot selecionado.</span>
               </article>
               <article className="dashboard-insight-card dashboard-insight-card--slate">
                 <header className="dashboard-insight-card__header">
@@ -1472,8 +1617,10 @@ export function AnaliseEstoquePage() {
                     <TrendIcon size={22} />
                   </span>
                 </header>
-                <strong className="dashboard-insight-card__value">{formatCurrency(previsaoSaidaTotal / 12)}</strong>
-                <span className="dashboard-insight-card__helper">Usada como referencia de cobertura financeira.</span>
+                <strong className="dashboard-insight-card__value">
+                  {formatCurrency(compraInsights.saidaMediaMensalPrevista || 0)}
+                </strong>
+                <span className="dashboard-insight-card__helper">Usada como referencia para cobertura e reposicao.</span>
               </article>
             </div>
             <div className="analysis-forecast-grid analysis-forecast-grid--equal">
@@ -1485,7 +1632,8 @@ export function AnaliseEstoquePage() {
                       <li key={`compra-imediata-${item.materialId || item.nome}`}>
                         <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
-                          Deficit: {formatNumber(item.deficitQuantidade)} | Estimado: {formatCurrency(item.deficitValor)}
+                          Deficit: {formatNumber(item.compra_minima_qtd ?? item.deficitQuantidade)} | Sugerido:{' '}
+                          {formatCurrency(item.valor_compra_sugerida ?? item.deficitValor)}
                         </span>
                       </li>
                     ))
@@ -1502,7 +1650,9 @@ export function AnaliseEstoquePage() {
                       <li key={`reposicao-${item.materialId || item.nome}`}>
                         <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
-                          Minimo: {formatNumber(item.estoqueMinimo)} | Atual: {formatNumber(item.estoqueAtual)}
+                          Minimo: {formatNumber(item.estoque_minimo ?? item.estoqueMinimo)} | Atual:{' '}
+                          {formatNumber(item.estoque_atual ?? item.estoqueAtual)} | Alvo:{' '}
+                          {formatNumber((item.estoque_alvo ?? item.pressaoVidaUtil) || 0)}
                         </span>
                       </li>
                     ))
@@ -1521,8 +1671,8 @@ export function AnaliseEstoquePage() {
                       <li key={`cobertura-${item.materialId || item.nome}`}>
                         <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
-                          Cobertura: {formatNumber(item.coberturaMeses || 0, 1)} mes | Giro/dia:{' '}
-                          {formatNumber(item.giroDiario || 0, 2)}
+                          Cobertura: {formatNumber((item.cobertura_meses ?? item.coberturaMeses) || 0, 1)} mes | Consumo/mês:{' '}
+                          {formatNumber((item.consumo_medio_mensal ?? item.giroDiario) || 0, 2)}
                         </span>
                       </li>
                     ))
@@ -1539,7 +1689,8 @@ export function AnaliseEstoquePage() {
                       <li key={`excesso-${item.materialId || item.nome}`}>
                         <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
-                          Atual: {formatNumber(item.estoqueAtual)} | Pressao: {formatNumber(item.pressaoVidaUtil || 0)}
+                          Atual: {formatNumber(item.estoque_atual ?? item.estoqueAtual)} | Alvo:{' '}
+                          {formatNumber((item.estoque_alvo ?? item.pressaoVidaUtil) || 0)}
                         </span>
                       </li>
                     ))
@@ -1566,6 +1717,8 @@ export function AnaliseEstoquePage() {
                   <span>Confianca: {forecastBase?.nivel_confianca || 'nao informada'}</span>
                   <span>Fator de tendencia: {formatNumber(forecastBase?.fator_tendencia || 1, 2)}</span>
                   <span>Variacao: {formatPercent(forecastBase?.variacao_percentual || 0, 2)}</span>
+                  {forecastAuditLoading ? <span>Atualizando auditoria do snapshot...</span> : null}
+                  {forecastAuditError ? <span>{forecastAuditError}</span> : null}
                   {forecastStatusMessage ? <span>{forecastStatusMessage}</span> : null}
                 </div>
                 <div className="analysis-forecast-actions">
@@ -1614,6 +1767,44 @@ export function AnaliseEstoquePage() {
                   <span className="dashboard-insight-card__helper">{card.helper}</span>
                 </article>
               ))}
+            </div>
+            <div className="analysis-forecast-grid analysis-forecast-grid--single">
+              <article className="analysis-forecast-card analysis-forecast-card--list">
+                <p className="analysis-forecast-label">Previsto x realizado</p>
+                <p className="analysis-forecast-subtitle">
+                  Viés positivo = forecast acima do realizado. Meses futuros continuam como pendentes.
+                </p>
+                {auditSerie.length ? (
+                  <div className="table-wrapper">
+                    <table className="data-table analysis-audit-table">
+                      <thead>
+                        <tr>
+                          <th>Mes</th>
+                          <th>Previsto</th>
+                          <th>Realizado</th>
+                          <th>Erro abs.</th>
+                          <th>Erro %</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {auditSerie.map((item) => (
+                          <tr key={`audit-${item.ano_mes}`}>
+                            <td>{item.label || formatLabelFromDate(item.ano_mes)}</td>
+                            <td>{formatCurrency(item.valor_previsto || 0)}</td>
+                            <td>{item.valor_realizado === null ? '-' : formatCurrency(item.valor_realizado || 0)}</td>
+                            <td>{item.erro_absoluto === null ? '-' : formatCurrency(item.erro_absoluto || 0)}</td>
+                            <td>{item.erro_percentual === null ? '-' : formatPercent(item.erro_percentual || 0, 2)}</td>
+                            <td>{item.status === 'realizado' ? 'Realizado' : 'Pendente'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="analysis-forecast-subtitle">Ainda nao ha meses realizados suficientes para comparar este snapshot.</p>
+                )}
+              </article>
             </div>
           </div>
         ) : null}

--- a/src/styles/DashboardPage.css
+++ b/src/styles/DashboardPage.css
@@ -678,6 +678,10 @@
   line-height: 1.35;
 }
 
+.analysis-forecast-card .table-wrapper {
+  margin-top: 0.25rem;
+}
+
 @media (max-width: 960px) {
   .analysis-pareto-grid {
     grid-template-columns: 1fr;

--- a/supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
+++ b/supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
@@ -1,0 +1,425 @@
+-- Etapas 2 e 3 do forecast:
+-- 1) Auditoria real do snapshot selecionado (previsto x realizado).
+-- 2) Planejamento de compra com regra de estoque/minimo/cobertura.
+
+create or replace function public.rpc_previsao_gasto_mensal_auditar(
+  p_owner_id uuid,
+  p_forecast_id uuid default null
+)
+returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_forecast_id uuid;
+  v_base_inicio date;
+  v_base_fim date;
+  v_created_at timestamptz;
+begin
+  select
+    id,
+    periodo_base_inicio,
+    periodo_base_fim,
+    created_at
+  into
+    v_forecast_id,
+    v_base_inicio,
+    v_base_fim,
+    v_created_at
+  from public.inventory_forecast
+  where account_owner_id = p_owner_id
+    and (p_forecast_id is null or id = p_forecast_id)
+  order by
+    case when id = p_forecast_id then 0 else 1 end,
+    created_at desc
+  limit 1;
+
+  if v_forecast_id is null then
+    return jsonb_build_object(
+      'status', 'missing',
+      'forecast_id', null,
+      'resumo', jsonb_build_object(
+        'meses_total', 0,
+        'meses_realizados', 0,
+        'meses_pendentes', 0
+      ),
+      'serie', '[]'::jsonb
+    );
+  end if;
+
+  return (
+    with ultimo_realizado as (
+      select max(ano_mes) as ano_mes
+      from public.agg_gasto_mensal
+      where account_owner_id = p_owner_id
+    ),
+    comparativo as (
+      select
+        p.ano_mes,
+        to_char(p.ano_mes, 'MM/YYYY') as label,
+        round(coalesce(p.valor_previsto, 0)::numeric, 2) as valor_previsto,
+        round(coalesce(p.valor_previsto_entrada, 0)::numeric, 2) as valor_previsto_entrada,
+        case
+          when ur.ano_mes is not null and p.ano_mes <= ur.ano_mes then round(coalesce(a.valor_saida, 0)::numeric, 2)
+          else null
+        end as valor_realizado,
+        case
+          when ur.ano_mes is not null and p.ano_mes <= ur.ano_mes then round((coalesce(p.valor_previsto, 0) - coalesce(a.valor_saida, 0))::numeric, 2)
+          else null
+        end as vies,
+        case
+          when ur.ano_mes is not null and p.ano_mes <= ur.ano_mes then round(abs(coalesce(p.valor_previsto, 0) - coalesce(a.valor_saida, 0))::numeric, 2)
+          else null
+        end as erro_absoluto,
+        case
+          when ur.ano_mes is not null
+            and p.ano_mes <= ur.ano_mes
+            and coalesce(a.valor_saida, 0) > 0
+            then round((((coalesce(p.valor_previsto, 0) - coalesce(a.valor_saida, 0)) / a.valor_saida) * 100)::numeric, 2)
+          else null
+        end as erro_percentual,
+        case
+          when ur.ano_mes is not null and p.ano_mes <= ur.ano_mes then 'realizado'
+          else 'pendente'
+        end as status
+      from public.f_previsao_gasto_mensal p
+      cross join ultimo_realizado ur
+      left join public.agg_gasto_mensal a
+        on a.account_owner_id = p_owner_id
+       and a.ano_mes = p.ano_mes
+      where p.account_owner_id = p_owner_id
+        and p.inventory_forecast_id = v_forecast_id
+        and p.cenario = 'base'
+      order by p.ano_mes
+    ),
+    resumo as (
+      select
+        count(*) as meses_total,
+        count(*) filter (where status = 'realizado') as meses_realizados,
+        count(*) filter (where status = 'pendente') as meses_pendentes,
+        round(coalesce(sum(valor_previsto) filter (where status = 'realizado'), 0)::numeric, 2) as total_previsto_realizado,
+        round(coalesce(sum(valor_realizado), 0)::numeric, 2) as total_realizado,
+        round(coalesce(sum(vies), 0)::numeric, 2) as vies_total,
+        round(coalesce(sum(erro_absoluto), 0)::numeric, 2) as erro_absoluto_total,
+        case
+          when coalesce(sum(valor_realizado), 0) > 0
+            then round(((sum(vies) / sum(valor_realizado)) * 100)::numeric, 2)
+          else null
+        end as vies_percentual,
+        case
+          when coalesce(sum(valor_realizado), 0) > 0
+            then round(((sum(erro_absoluto) / sum(valor_realizado)) * 100)::numeric, 2)
+          else null
+        end as wape_percentual,
+        case
+          when count(*) filter (where status = 'realizado' and coalesce(valor_realizado, 0) > 0) > 0
+            then round(
+              coalesce(avg(abs(erro_percentual)) filter (where status = 'realizado' and coalesce(valor_realizado, 0) > 0), 0)::numeric,
+              2
+            )
+          else null
+        end as mape_percentual
+      from comparativo
+    )
+    select jsonb_build_object(
+      'status', 'ok',
+      'forecast_id', v_forecast_id,
+      'periodo_base_inicio', v_base_inicio,
+      'periodo_base_fim', v_base_fim,
+      'created_at', v_created_at,
+      'resumo', jsonb_build_object(
+        'meses_total', r.meses_total,
+        'meses_realizados', r.meses_realizados,
+        'meses_pendentes', r.meses_pendentes,
+        'total_previsto_realizado', r.total_previsto_realizado,
+        'total_realizado', r.total_realizado,
+        'vies_total', r.vies_total,
+        'erro_absoluto_total', r.erro_absoluto_total,
+        'vies_percentual', r.vies_percentual,
+        'wape_percentual', r.wape_percentual,
+        'mape_percentual', r.mape_percentual,
+        'acuracia_wape', greatest(0, round((100 - coalesce(r.wape_percentual, 100))::numeric, 2)),
+        'acuracia_mape', greatest(0, round((100 - coalesce(r.mape_percentual, 100))::numeric, 2))
+      ),
+      'serie', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'ano_mes', c.ano_mes,
+            'label', c.label,
+            'valor_previsto', c.valor_previsto,
+            'valor_previsto_entrada', c.valor_previsto_entrada,
+            'valor_realizado', c.valor_realizado,
+            'vies', c.vies,
+            'erro_absoluto', c.erro_absoluto,
+            'erro_percentual', c.erro_percentual,
+            'status', c.status
+          ) order by c.ano_mes
+        )
+        from comparativo c
+      ), '[]'::jsonb)
+    )
+    from resumo r
+  );
+end;
+$$;
+
+create or replace function public.rpc_previsao_compra_sugerida(
+  p_owner_id uuid,
+  p_forecast_id uuid default null
+)
+returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_forecast_id uuid;
+  v_prev_entrada numeric := 0;
+  v_prev_saida numeric := 0;
+  v_prev_saldo numeric := 0;
+begin
+  select
+    id,
+    coalesce(previsao_anual_entrada, 0),
+    coalesce(previsao_anual_saida, 0),
+    coalesce(previsao_anual_saldo, 0)
+  into
+    v_forecast_id,
+    v_prev_entrada,
+    v_prev_saida,
+    v_prev_saldo
+  from public.inventory_forecast
+  where account_owner_id = p_owner_id
+    and (p_forecast_id is null or id = p_forecast_id)
+  order by
+    case when id = p_forecast_id then 0 else 1 end,
+    created_at desc
+  limit 1;
+
+  return (
+    with entradas_saldo as (
+      select
+        e."materialId"::text as material_id,
+        sum(e.quantidade)::numeric as quantidade
+      from public.entradas e
+      left join public.status_entrada se on se.id = e.status
+      where e.account_owner_id = p_owner_id
+        and coalesce(lower(se.status), lower(coalesce(e.status::text, ''))) <> 'cancelado'
+      group by e."materialId"
+    ),
+    saidas_saldo as (
+      select
+        s."materialId"::text as material_id,
+        sum(s.quantidade)::numeric as quantidade
+      from public.saidas s
+      left join public.status_saida ss on ss.id = s.status
+      where s.account_owner_id = p_owner_id
+        and coalesce(lower(ss.status), lower(coalesce(s.status::text, ''))) <> 'cancelado'
+      group by s."materialId"
+    ),
+    saidas_90d as (
+      select
+        s."materialId"::text as material_id,
+        sum(s.quantidade)::numeric as quantidade
+      from public.saidas s
+      left join public.status_saida ss on ss.id = s.status
+      where s.account_owner_id = p_owner_id
+        and coalesce(lower(ss.status), lower(coalesce(s.status::text, ''))) <> 'cancelado'
+        and s."dataEntrega" >= (current_date - interval '90 days')
+      group by s."materialId"
+    ),
+    saidas_180d as (
+      select
+        s."materialId"::text as material_id,
+        sum(s.quantidade)::numeric as quantidade
+      from public.saidas s
+      left join public.status_saida ss on ss.id = s.status
+      where s.account_owner_id = p_owner_id
+        and coalesce(lower(ss.status), lower(coalesce(s.status::text, ''))) <> 'cancelado'
+        and s."dataEntrega" >= (current_date - interval '180 days')
+      group by s."materialId"
+    ),
+    base as (
+      select
+        m.id as material_id,
+        m.nome,
+        round(coalesce(m."valorUnitario", 0)::numeric, 2) as valor_unitario,
+        coalesce(m."estoqueMinimo", 0)::numeric as estoque_minimo,
+        coalesce(es.quantidade, 0) - coalesce(ss.quantidade, 0) as estoque_atual,
+        coalesce(s90.quantidade, 0) as qtd_saida_90d,
+        coalesce(s180.quantidade, 0) as qtd_saida_180d,
+        case
+          when coalesce(s90.quantidade, 0) > 0 then round((s90.quantidade / 3.0)::numeric, 2)
+          when coalesce(s180.quantidade, 0) > 0 then round((s180.quantidade / 6.0)::numeric, 2)
+          else 0
+        end as consumo_medio_mensal
+      from public.materiais m
+      left join entradas_saldo es on es.material_id = m.id::text
+      left join saidas_saldo ss on ss.material_id = m.id::text
+      left join saidas_90d s90 on s90.material_id = m.id::text
+      left join saidas_180d s180 on s180.material_id = m.id::text
+      where m.account_owner_id = p_owner_id
+        and coalesce(m.ativo, true) = true
+    ),
+    enriquecido as (
+      select
+        b.*,
+        case
+          when b.consumo_medio_mensal > 0 then round((b.estoque_atual / b.consumo_medio_mensal)::numeric, 2)
+          else null
+        end as cobertura_meses,
+        greatest(
+          b.estoque_minimo,
+          ceil(greatest(b.consumo_medio_mensal, 0) * 2.0)
+        )::numeric as estoque_alvo,
+        greatest(b.estoque_minimo - b.estoque_atual, 0)::numeric as compra_minima_qtd
+      from base b
+    ),
+    classificado as (
+      select
+        e.*,
+        greatest(e.estoque_alvo - e.estoque_atual, 0)::numeric as compra_sugerida_qtd,
+        round((e.compra_minima_qtd * e.valor_unitario)::numeric, 2) as valor_compra_minima,
+        round((greatest(e.estoque_alvo - e.estoque_atual, 0) * e.valor_unitario)::numeric, 2) as valor_compra_sugerida,
+        case
+          when e.estoque_atual < e.estoque_minimo or (e.cobertura_meses is not null and e.cobertura_meses < 1) then 'imediata'
+          when greatest(e.estoque_alvo - e.estoque_atual, 0) > 0 or (e.cobertura_meses is not null and e.cobertura_meses < 2) then 'planejada'
+          else 'ok'
+        end as prioridade,
+        case
+          when (e.consumo_medio_mensal = 0 and e.estoque_atual > greatest(e.estoque_minimo * 2, 1))
+            or (e.cobertura_meses is not null and e.cobertura_meses > 6 and e.estoque_atual > e.estoque_minimo)
+            then true
+          else false
+        end as excesso_flag
+      from enriquecido e
+    ),
+    resumo as (
+      select
+        count(*) as materiais_monitorados,
+        count(*) filter (where estoque_atual < estoque_minimo) as itens_abaixo_minimo,
+        count(*) filter (where prioridade = 'imediata') as itens_compra_imediata,
+        count(*) filter (where prioridade = 'planejada') as itens_reposicao_planejada,
+        count(*) filter (where cobertura_meses is not null and cobertura_meses < 1) as itens_cobertura_curta,
+        count(*) filter (where excesso_flag) as itens_excesso,
+        round(coalesce(sum(compra_minima_qtd), 0)::numeric, 2) as quantidade_compra_minima,
+        round(coalesce(sum(valor_compra_minima), 0)::numeric, 2) as valor_compra_minima,
+        round(coalesce(sum(compra_sugerida_qtd), 0)::numeric, 2) as quantidade_compra_sugerida,
+        round(coalesce(sum(valor_compra_sugerida), 0)::numeric, 2) as valor_compra_sugerida,
+        round(coalesce(avg(cobertura_meses), 0)::numeric, 2) as cobertura_media_meses
+      from classificado
+    )
+    select jsonb_build_object(
+      'status', 'ok',
+      'forecast_id', v_forecast_id,
+      'resumo', jsonb_build_object(
+        'materiais_monitorados', r.materiais_monitorados,
+        'itens_abaixo_minimo', r.itens_abaixo_minimo,
+        'itens_compra_imediata', r.itens_compra_imediata,
+        'itens_reposicao_planejada', r.itens_reposicao_planejada,
+        'itens_cobertura_curta', r.itens_cobertura_curta,
+        'itens_excesso', r.itens_excesso,
+        'quantidade_compra_minima', r.quantidade_compra_minima,
+        'valor_compra_minima', r.valor_compra_minima,
+        'quantidade_compra_sugerida', r.quantidade_compra_sugerida,
+        'valor_compra_sugerida', r.valor_compra_sugerida,
+        'cobertura_media_meses', r.cobertura_media_meses,
+        'saida_media_mensal_prevista', round((coalesce(v_prev_saida, 0) / 12.0)::numeric, 2),
+        'entrada_media_mensal_prevista', round((coalesce(v_prev_entrada, 0) / 12.0)::numeric, 2),
+        'saldo_anual_previsto', round(coalesce(v_prev_saldo, 0)::numeric, 2)
+      ),
+      'compra_imediata', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'material_id', q.material_id,
+            'nome', q.nome,
+            'estoque_atual', q.estoque_atual,
+            'estoque_minimo', q.estoque_minimo,
+            'estoque_alvo', q.estoque_alvo,
+            'consumo_medio_mensal', q.consumo_medio_mensal,
+            'cobertura_meses', q.cobertura_meses,
+            'compra_minima_qtd', q.compra_minima_qtd,
+            'compra_sugerida_qtd', q.compra_sugerida_qtd,
+            'valor_compra_minima', q.valor_compra_minima,
+            'valor_compra_sugerida', q.valor_compra_sugerida,
+            'valor_unitario', q.valor_unitario
+          )
+        )
+        from (
+          select *
+          from classificado
+          where prioridade = 'imediata'
+          order by valor_compra_sugerida desc, cobertura_meses asc nulls first, nome
+          limit 5
+        ) q
+      ), '[]'::jsonb),
+      'reposicao_planejada', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'material_id', q.material_id,
+            'nome', q.nome,
+            'estoque_atual', q.estoque_atual,
+            'estoque_minimo', q.estoque_minimo,
+            'estoque_alvo', q.estoque_alvo,
+            'consumo_medio_mensal', q.consumo_medio_mensal,
+            'cobertura_meses', q.cobertura_meses,
+            'compra_sugerida_qtd', q.compra_sugerida_qtd,
+            'valor_compra_sugerida', q.valor_compra_sugerida,
+            'valor_unitario', q.valor_unitario
+          )
+        )
+        from (
+          select *
+          from classificado
+          where prioridade = 'planejada'
+          order by valor_compra_sugerida desc, cobertura_meses asc nulls first, nome
+          limit 5
+        ) q
+      ), '[]'::jsonb),
+      'cobertura_curta', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'material_id', q.material_id,
+            'nome', q.nome,
+            'estoque_atual', q.estoque_atual,
+            'estoque_minimo', q.estoque_minimo,
+            'consumo_medio_mensal', q.consumo_medio_mensal,
+            'cobertura_meses', q.cobertura_meses,
+            'compra_sugerida_qtd', q.compra_sugerida_qtd,
+            'valor_compra_sugerida', q.valor_compra_sugerida
+          )
+        )
+        from (
+          select *
+          from classificado
+          where cobertura_meses is not null
+            and cobertura_meses < 1
+          order by cobertura_meses asc, valor_compra_sugerida desc, nome
+          limit 5
+        ) q
+      ), '[]'::jsonb),
+      'excesso_ou_baixo_giro', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'material_id', q.material_id,
+            'nome', q.nome,
+            'estoque_atual', q.estoque_atual,
+            'estoque_minimo', q.estoque_minimo,
+            'estoque_alvo', q.estoque_alvo,
+            'consumo_medio_mensal', q.consumo_medio_mensal,
+            'cobertura_meses', q.cobertura_meses,
+            'valor_unitario', q.valor_unitario
+          )
+        )
+        from (
+          select *
+          from classificado
+          where excesso_flag
+          order by cobertura_meses desc nulls last, estoque_atual desc, nome
+          limit 5
+        ) q
+      ), '[]'::jsonb)
+    )
+    from resumo r
+  );
+end;
+$$;


### PR DESCRIPTION
…sugerida

- O que foi feito:
  - cria migration com rpc_previsao_gasto_mensal_auditar para comparar previsto x realizado por snapshot
  - cria migration com rpc_previsao_compra_sugerida para recomendacao de compra por estoque atual, minimo e cobertura
  - ajusta AnaliseEstoquePage para carregar auditoria e compra a partir do forecast_id selecionado
  - faz a aba Compra priorizar o backend e manter fallback local se a RPC ainda nao estiver disponivel
  - amplia a aba Auditoria com WAPE, MAPE, vies e tabela mensal previsto x realizado
  - atualiza docs da tela, ajuda contextual, TASKS e README

- Arquivos tocados:
  - supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
  - src/pages/AnaliseEstoquePage.jsx
  - src/styles/DashboardPage.css
  - src/help/helpAnaliseEstoque.json
  - docs/AnaliseEstoque.txt
  - TASKS.md
  - README.md

- Mapeamento por modulo/tela:
  - Analise de Estoque: abas Compra e Auditoria deixam de ser apenas leitura visual e passam a consumir RPCs especificos
  - Forecast auditoria: compara f_previsao_gasto_mensal com agg_gasto_mensal no snapshot selecionado
  - Forecast compra: calcula reposicao por tenant com estoque atual, estoque minimo, consumo recente e cobertura
  - Docs: registra o comportamento novo das etapas 2 e 3 e a migration correspondente

- Como validar:
  - npm run build
  - abrir /analise-estoque
  - trocar o periodo do forecast
  - validar cards e tabela da aba Auditoria
  - validar listas e cards da aba Compra
  - aplicar as migrations no Supabase e testar as RPCs no banco real

- Impacto multi-tenant:
  - RPCs filtram por account_owner_id
  - leitura continua tenant-scoped
  - sem mudanca de RLS nas tabelas; execucao segue com o contexto autenticado

- Docs:
  - docs/AnaliseEstoque.txt atualizado
  - src/help/helpAnaliseEstoque.json atualizado
  - TASKS.md atualizado
  - README.md atualizado