### PR TITLE
fix(forecast): corrigir RPCs de auditoria e compra para security definer

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,7 @@ supabase/
     20260418_aso_mudanca_funcao_e_baixa_com_tipo.sql  # migration SQL
     20260423_fix_forecast_snapshot_versioning.sql  # migration SQL
     20260423_add_forecast_audit_and_purchase_rpcs.sql  # migration SQL
+    20260423_fix_forecast_audit_purchase_security_definer.sql  # migration SQL
   migrations_rebuild/
     0001_extensions.sql  # migration rebuild SQL
     0002_tables.sql  # migration rebuild SQL

--- a/TASKS.md
+++ b/TASKS.md
@@ -36,6 +36,7 @@
 - Snapshot de forecast passou a preservar as linhas mensais por `inventory_forecast_id`, evitando que um forecast novo sobrescreva a previsao mensal de um snapshot antigo.
 - API de forecast (`api/_shared/operations.js`) passou a ler a serie mensal pelo `forecast_id` selecionado/derivado do resumo.
 - Tela `Analise de Estoque` passou a consumir auditoria real do snapshot (`previsto x realizado`, WAPE/MAPE, vies) e RPC de compra sugerida por estoque/minimo/cobertura.
+- Aba `Compra` da Analise de Estoque passou a reaproveitar o resumo do `estoqueBase` para nao exibir UUID bruto nas listas quando o RPC retorna apenas `material_id`.
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
@@ -43,6 +44,7 @@
 - Aplicar a migration `supabase/migrations/20260412_aso_baixa_e_historico.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260423_fix_forecast_snapshot_versioning.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql` no projeto Supabase.
+- Aplicar a migration `supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql` no projeto Supabase.
 - Aplicar no projeto Supabase, nesta ordem:
   - `supabase/migrations/20260418_01_aso_mudanca_funcao_schema.sql`
   - `supabase/migrations/20260418_02_aso_rpc_create_full.sql`

--- a/docs/AnaliseEstoque.txt
+++ b/docs/AnaliseEstoque.txt
@@ -160,11 +160,15 @@ Atualizacao 2026-04 (auditoria e compra)
 - Migration `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql` criada com dois RPCs novos:
   - `rpc_previsao_gasto_mensal_auditar(p_owner_id, p_forecast_id)` para comparar previsto x realizado por snapshot.
   - `rpc_previsao_compra_sugerida(p_owner_id, p_forecast_id)` para calcular compra sugerida por estoque atual, minimo e cobertura.
+- Os dois RPCs de auditoria/compra rodam como `security definer`, seguindo o padrao do projeto para nao quebrar por RLS em `entradas`, `saidas` e `agg_gasto_mensal`.
+- Migration `supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql` foi adicionada para corrigir ambientes onde a migration anterior ja tenha sido aplicada sem `security definer`.
 - A aba `Auditoria` passou a consumir a auditoria real do snapshot selecionado, com meses auditados, viés, WAPE/MAPE e tabela mensal previsto x realizado.
 - A aba `Compra` passou a priorizar o payload do RPC de compra; se o RPC nao estiver disponivel, o front ainda cai no fallback local anterior.
+- A lista da aba `Compra` passou a reutilizar o resumo/nome ja carregado em `estoqueBase` para evitar exibicao de UUID bruto quando o payload do RPC nao traz um nome amigavel.
 - `diagnosticar_estatisticas_mensais` continua existindo para leitura estatistica historica; ele nao foi substituido pela auditoria do snapshot.
 - Arquivos alterados:
 - `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql`
+- `supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql`
 - `src/pages/AnaliseEstoquePage.jsx`
 - `src/styles/DashboardPage.css`
 - `src/help/helpAnaliseEstoque.json`

--- a/src/pages/AnaliseEstoquePage.jsx
+++ b/src/pages/AnaliseEstoquePage.jsx
@@ -1059,6 +1059,16 @@ export function AnaliseEstoquePage() {
   )
   const forecastCreatedAtLabel = formatForecastTimestamp(forecastBase?.created_at)
   const selectedForecastId = forecastBase?.id || null
+  const materialDisplayMap = useMemo(() => {
+    const map = new Map()
+    const estoqueItens = Array.isArray(estoqueBase?.itens) ? estoqueBase.itens : []
+    estoqueItens.forEach((item) => {
+      const key = String(item.materialId || item.id || '')
+      if (!key) return
+      map.set(key, item.resumo || item.nome || item.descricao || key)
+    })
+    return map
+  }, [estoqueBase])
 
   useEffect(() => {
     const shouldUseSupabase = !isLocalMode && isSupabaseConfigured() && supabase && profile?.owner_id
@@ -1133,6 +1143,20 @@ export function AnaliseEstoquePage() {
   const compraInsights = useMemo(() => {
     if (forecastCompraPayload?.status === 'ok') {
       const resumo = forecastCompraPayload?.resumo || {}
+      const enrichList = (list = []) =>
+        list.map((item) => {
+          const materialKey = String(item.material_id || item.materialId || '')
+          return {
+            ...item,
+            displayNome:
+              materialDisplayMap.get(materialKey) ||
+              item.nome ||
+              item.descricao ||
+              item.materialIdDisplay ||
+              item.materialId ||
+              materialKey,
+          }
+        })
       return {
         materiaisMonitorados: Number(resumo.materiais_monitorados || 0),
         itensAbaixoMinimo: Number(resumo.itens_abaixo_minimo || 0),
@@ -1151,16 +1175,14 @@ export function AnaliseEstoquePage() {
         saidaMediaMensalPrevista: Number(resumo.saida_media_mensal_prevista || 0),
         entradaMediaMensalPrevista: Number(resumo.entrada_media_mensal_prevista || 0),
         saldoAnualPrevisto: Number(resumo.saldo_anual_previsto || 0),
-        compraImediata: Array.isArray(forecastCompraPayload?.compra_imediata) ? forecastCompraPayload.compra_imediata : [],
-        reposicaoPlanejada: Array.isArray(forecastCompraPayload?.reposicao_planejada)
-          ? forecastCompraPayload.reposicao_planejada
-          : [],
-        excessoOuBaixoGiro: Array.isArray(forecastCompraPayload?.excesso_ou_baixo_giro)
-          ? forecastCompraPayload.excesso_ou_baixo_giro
-          : [],
-        semCoberturaCurta: Array.isArray(forecastCompraPayload?.cobertura_curta)
-          ? forecastCompraPayload.cobertura_curta
-          : [],
+        compraImediata: enrichList(Array.isArray(forecastCompraPayload?.compra_imediata) ? forecastCompraPayload.compra_imediata : []),
+        reposicaoPlanejada: enrichList(
+          Array.isArray(forecastCompraPayload?.reposicao_planejada) ? forecastCompraPayload.reposicao_planejada : [],
+        ),
+        excessoOuBaixoGiro: enrichList(
+          Array.isArray(forecastCompraPayload?.excesso_ou_baixo_giro) ? forecastCompraPayload.excesso_ou_baixo_giro : [],
+        ),
+        semCoberturaCurta: enrichList(Array.isArray(forecastCompraPayload?.cobertura_curta) ? forecastCompraPayload.cobertura_curta : []),
         origem: 'rpc',
       }
     }
@@ -1241,7 +1263,7 @@ export function AnaliseEstoquePage() {
       semCoberturaCurta: semCoberturaCurta.slice(0, 5),
       origem: 'fallback',
     }
-  }, [estoqueBase, forecastCompraPayload, previsaoEntradaTotal, previsaoSaidaTotal, previsaoSaldoTotal, riscoOperacional])
+  }, [estoqueBase, forecastCompraPayload, materialDisplayMap, previsaoEntradaTotal, previsaoSaidaTotal, previsaoSaldoTotal, riscoOperacional])
 
   const auditResumo = forecastAuditPayload?.resumo || null
   const auditSerie = useMemo(
@@ -1630,7 +1652,7 @@ export function AnaliseEstoquePage() {
                   {compraInsights.compraImediata.length ? (
                     compraInsights.compraImediata.map((item) => (
                       <li key={`compra-imediata-${item.materialId || item.nome}`}>
-                        <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
+                        <strong>{item.displayNome || item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
                           Deficit: {formatNumber(item.compra_minima_qtd ?? item.deficitQuantidade)} | Sugerido:{' '}
                           {formatCurrency(item.valor_compra_sugerida ?? item.deficitValor)}
@@ -1648,7 +1670,7 @@ export function AnaliseEstoquePage() {
                   {compraInsights.reposicaoPlanejada.length ? (
                     compraInsights.reposicaoPlanejada.map((item) => (
                       <li key={`reposicao-${item.materialId || item.nome}`}>
-                        <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
+                        <strong>{item.displayNome || item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
                           Minimo: {formatNumber(item.estoque_minimo ?? item.estoqueMinimo)} | Atual:{' '}
                           {formatNumber(item.estoque_atual ?? item.estoqueAtual)} | Alvo:{' '}
@@ -1669,7 +1691,7 @@ export function AnaliseEstoquePage() {
                   {compraInsights.semCoberturaCurta.length ? (
                     compraInsights.semCoberturaCurta.map((item) => (
                       <li key={`cobertura-${item.materialId || item.nome}`}>
-                        <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
+                        <strong>{item.displayNome || item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
                           Cobertura: {formatNumber((item.cobertura_meses ?? item.coberturaMeses) || 0, 1)} mes | Consumo/mês:{' '}
                           {formatNumber((item.consumo_medio_mensal ?? item.giroDiario) || 0, 2)}
@@ -1687,7 +1709,7 @@ export function AnaliseEstoquePage() {
                   {compraInsights.excessoOuBaixoGiro.length ? (
                     compraInsights.excessoOuBaixoGiro.map((item) => (
                       <li key={`excesso-${item.materialId || item.nome}`}>
-                        <strong>{item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
+                        <strong>{item.displayNome || item.nome || item.descricao || item.materialIdDisplay || item.materialId}</strong>
                         <span>
                           Atual: {formatNumber(item.estoque_atual ?? item.estoqueAtual)} | Alvo:{' '}
                           {formatNumber((item.estoque_alvo ?? item.pressaoVidaUtil) || 0)}

--- a/supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
+++ b/supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
@@ -8,6 +8,7 @@ create or replace function public.rpc_previsao_gasto_mensal_auditar(
 )
 returns jsonb
 language plpgsql
+security definer
 set search_path = public
 as $$
 declare
@@ -169,6 +170,7 @@ create or replace function public.rpc_previsao_compra_sugerida(
 )
 returns jsonb
 language plpgsql
+security definer
 set search_path = public
 as $$
 declare

--- a/supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql
+++ b/supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql
@@ -1,0 +1,10 @@
+-- Corrige as RPCs de auditoria/compra do forecast para seguirem o padrao
+-- do projeto e nao quebrarem por RLS no banco.
+
+alter function public.rpc_previsao_gasto_mensal_auditar(uuid, uuid)
+  security definer
+  set search_path = public;
+
+alter function public.rpc_previsao_compra_sugerida(uuid, uuid)
+  security definer
+  set search_path = public;


### PR DESCRIPTION
- O que foi feito:
  - ajusta as RPCs de auditoria e compra do forecast para seguirem o padrao security definer
  - adiciona migration corretiva para ambientes onde a migration inicial ja foi aplicada
  - documenta que o erro de RLS nao deve aparecer ao usuario

- Arquivos tocados:
  - supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql
  - supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql
  - docs/AnaliseEstoque.txt
  - TASKS.md
  - README.md

- Mapeamento por modulo/tela:
  - Forecast SQL: RPCs de auditoria e compra passam a executar sem quebrar por RLS
  - Analise de Estoque: abas Compra e Auditoria deixam de depender de permissoes diretas nas tabelas base

- Como validar:
  - aplicar as duas migrations no Supabase
  - abrir /analise-estoque
  - validar que nao aparece mais erro de row-level security
  - validar carga das abas Compra e Auditoria

- Impacto multi-tenant:
  - mantido o filtro por account_owner_id
  - sem vazamento entre tenants
  - ajuste apenas na forma de execucao das RPCs

- Docs:
  - docs/AnaliseEstoque.txt atualizado
  - TASKS.md atualizado
  - README.md atualizado