### PR TITLE
docs(seguranca): documentar plano e referencias arquiteturais

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -37,8 +37,13 @@
 - API de forecast (`api/_shared/operations.js`) passou a ler a serie mensal pelo `forecast_id` selecionado/derivado do resumo.
 - Tela `Analise de Estoque` passou a consumir auditoria real do snapshot (`previsto x realizado`, WAPE/MAPE, vies) e RPC de compra sugerida por estoque/minimo/cobertura.
 - Aba `Compra` da Analise de Estoque passou a reaproveitar o resumo do `estoqueBase` para nao exibir UUID bruto nas listas quando o RPC retorna apenas `material_id`.
+- Documentacao de referencia arquitetural foi adicionada em `docs/Estruturas`, cobrindo arquitetura limpa, autenticacao, nomenclatura, RLS, Realtime e comparativo de sessoes.
+- Plano de correcao de vulnerabilidades de seguranca foi documentado em `docs/Plano de Correção — Vulnerabilidades de Segurança.txt`.
 
 ## Pendente
+- Confirmar dominios de producao/staging para configurar whitelist CORS via `CORS_ALLOWED_ORIGINS`.
+- Definir escopo do rate limit de leitura: apenas rotas sensiveis ou global.
+- Confirmar criacao da migration de `audit_log` e validar nomes reais das tabelas/colunas de permissoes antes da RPC `get_user_effective_permissions`.
 - Aplicar a migration `supabase/migrations/20260412_create_aso_control.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260412_add_aso_page_permissions.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260412_aso_baixa_e_historico.sql` no projeto Supabase.

--- a/docs/Estruturas/Arquitetura de Software Estrutura e Princípios.txt
+++ b/docs/Estruturas/Arquitetura de Software Estrutura e Princípios.txt
@@ -1,0 +1,95 @@
+Com certeza! Com base nas fontes fornecidas, preparei um mapa mental que detalha o passo a passo para criar uma estrutura robusta e bem definida para softwares e aplicativos. Este mapa mental aborda desde os princípios fundamentais até as decisões de implementação prática.
+Mapa Mental: Passo a Passo para Criar a Estrutura de Software e Apps
+1. Fundamentos e Filosofia da Arquitetura
+Objetivo Principal: O objetivo da arquitetura de software é minimizar os recursos humanos necessários para construir e manter o sistema
+. Uma boa arquitetura torna o sistema fácil de entender, desenvolver, manter e implantar
+.
+Dois Valores do Software: Todo sistema de software possui dois valores: comportamento (o que ele faz) e estrutura (a arquitetura)
+. A estrutura é o valor maior, pois garante que o software seja "soft", ou seja, fácil de mudar
+.
+Manter Opções Abertas: Uma boa arquitetura deixa o máximo de opções abertas pelo maior tempo possível
+. Ela adia e posterga decisões sobre detalhes como frameworks, bancos de dados e servidores web, permitindo que o foco permaneça nas regras de negócio
+.
+A Arquitetura Grita o Caso de Uso: A estrutura de alto nível do seu aplicativo deve "gritar" qual é o seu propósito (por exemplo, "Sistema de Saúde" ou "Sistema de Contabilidade"), e não quais frameworks você usou (como "Rails" ou "Spring")
+.
+2. Definindo as Regras de Negócio (O Coração do Sistema)
+Identificar Regras de Negócio Críticas (Entidades): Estas são as regras que fazem ou economizam dinheiro para o negócio, independentemente da automação
+. Elas são encapsuladas em objetos chamados Entidades, que contêm os dados e as regras mais gerais e de alto nível
+. As Entidades devem ser puras, sem conhecimento sobre UI, banco de dados ou frameworks
+.
+Identificar Casos de Uso: Descrevem como o sistema automatizado é usado, orquestrando o fluxo de dados e direcionando as Entidades para atingir os objetivos
+. Eles representam as regras de negócio específicas da aplicação
+.
+Independência: Casos de uso não devem descrever a UI, apenas a interação entre o usuário e as Entidades
+.
+3. Princípios de Design (SOLID)
+Os princípios SOLID orientam como organizar funções e estruturas de dados em classes e como essas classes devem se interconectar
+.
+SRP (Princípio da Responsabilidade Única): Um módulo deve ter apenas um, e somente um, ator (grupo de usuários/stakeholders) para mudar
+. Separe o código que diferentes atores dependem
+.
+OCP (Princípio Aberto-Fechado): O software deve ser aberto para extensão, mas fechado para modificação
+. Adicione novos comportamentos sem alterar o código existente, protegendo componentes de alto nível de mudanças nos de baixo nível
+.
+LSP (Princípio da Substituição de Liskov): Partes intercambiáveis devem aderir a um contrato que permita que uma seja substituída pela outra sem quebrar o sistema
+.
+ISP (Princípio da Segregação de Interface): Evite depender de coisas que você não usa
+. Isso se aplica a classes com muitos métodos e a componentes com muitas classes
+.
+DIP (Princípio da Inversão de Dependência): O código que implementa políticas de alto nível não deve depender do código que implementa detalhes de baixo nível. Detalhes devem depender de políticas
+.
+4. Estruturando em Camadas e Componentes (A Arquitetura Limpa)
+A Regra da Dependência: As dependências do código-fonte devem apontar apenas para dentro, em direção às políticas de nível superior
+. Nada em um círculo interno pode saber sobre algo em um círculo externo
+.
+Divisão em Camadas concêntricas:
+Entidades (Círculo mais interno): Regras de negócio críticas para toda a empresa
+.
+Casos de Uso: Regras de negócio específicas da aplicação
+.
+Adaptadores de Interface (Presenters, Controllers, Gateways): Convertem dados do formato mais conveniente para os casos de uso e entidades para o formato mais conveniente para agências externas (UI, Banco de Dados, Web)
+.
+Frameworks e Drivers (Círculo mais externo): Onde todos os detalhes vão (Web, Banco de Dados, UI Frameworks)
+.
+Limites Arquitetônicos (Boundaries):
+Desenhe linhas que separam os elementos do software, restringindo o conhecimento de um lado sobre o outro
+.
+Use interfaces polimórficas para cruzar os limites, invertendo a dependência contra o fluxo de controle para seguir a Regra da Dependência
+.
+O padrão Humble Object é útil para definir limites. Ele separa comportamentos difíceis de testar (como a UI) dos fáceis de testar (como Presenters)
+.
+5. Estrutura da Aplicação (Implementação Prática)
+Organização do Código: A forma como você organiza o código em pacotes/módulos é crucial para reforçar a arquitetura
+.
+Pacote por Camada (Horizontal): Agrupa o código por função técnica (ex: web, services, repositories)
+. É um bom ponto de partida, mas não "grita" o domínio do negócio
+.
+Pacote por Funcionalidade (Vertical): Agrupa todo o código relacionado a uma funcionalidade em um único pacote (ex: orders)
+. Melhora a visibilidade do domínio
+.
+Pacote por Componente: Uma abordagem híbrida que agrupa lógica de negócios e persistência em um único componente, expondo uma interface limpa
+. Ajuda a usar o compilador para reforçar a arquitetura
+.
+Camadas em Apps Modernos (Ex: Android):
+Camada de IU (UI Layer): Responsável por exibir os dados do app na tela e lidar com a interação do usuário
+. Segue o Fluxo de Dados Unidirecional (UDF), onde o estado flui para baixo (do ViewModel para a UI) e os eventos fluem para cima (da UI para o ViewModel)
+.
+Camada de Domínio (Domain Layer): Uma camada opcional entre a UI e a camada de dados para encapsular a lógica de negócios complexa ou reutilizável
+. Use UseCases para isso
+.
+Camada de Dados (Data Layer): Responsável por fornecer os dados do aplicativo, geralmente por meio do padrão de Repositório
+.
+O Componente Main: É o detalhe final, o componente de mais baixo nível
+. Sua responsabilidade é criar todas as fábricas e dependências e, em seguida, entregar o controle para as partes abstratas de alto nível do sistema
+. Pense nele como um plugin para a aplicação
+.
+6. Testabilidade como Guia
+Arquitetura Testável: Uma boa arquitetura é intrinsecamente testável
+. As regras de negócio devem ser testáveis sem a UI, banco de dados ou servidor web
+.
+Testes são Componentes do Sistema: Os testes seguem a Regra da Dependência, apontando para dentro, e são o círculo mais externo da arquitetura
+.
+Projete para Testabilidade: Crie uma API de Teste para desacoplar os testes da estrutura da aplicação, evitando o problema de "Testes Frágeis"
+. A lógica de negócios não deve depender de elementos voláteis como a UI para ser testada
+.
+Este mapa mental fornece uma visão estruturada, guiando desde os conceitos de alto nível até as decisões práticas de implementação, sempre com o objetivo de criar um software flexível, sustentável e de fácil manutenção.

--- a/docs/Estruturas/Arquitetura e Fluxos da Autenticação Moderna e Sessões.txt
+++ b/docs/Estruturas/Arquitetura e Fluxos da Autenticação Moderna e Sessões.txt
@@ -1,0 +1,35 @@
+Com base nas fontes, o fluxo do processo de autenticação moderna e gerenciamento de sessões (que fundamenta o funcionamento do Supabase) pode ser dividido nos seguintes estágios:
+1. Fluxo de Autenticação com Credenciais (E-mail e Senha)
+Entrada do Usuário: O usuário insere e-mail e senha no cliente
+.
+Processamento de Segurança (Back-end):
+O servidor recebe a senha e aplica uma função de hash lenta (como Bcrypt ou Argon2) para segurança contra ataques de força bruta
+.
+O sistema utiliza um salt (valor aleatório) para garantir que usuários com senhas iguais tenham hashes diferentes no banco de dados
+.
+Validação de Identidade: O servidor compara o hash gerado com o armazenado. Se coincidirem, a identidade é provada
+.
+Segundo Fator (MFA): O sistema solicita um segundo fator de autenticação, como um código TOTP (gerado por apps como Google Authenticator) ou uma assinatura de desafio via Passkey
+.
+Emissão de Tokens: Uma vez autenticado, o servidor gera um Access Token (JWT) de curta duração (ex: 15 minutos) e um Refresh Token
+.
+2. Fluxo de Requisições Autorizadas
+Envio do Token: O cliente armazena o token (preferencialmente em cookies httpOnly para proteção contra XSS) e o envia no cabeçalho Authorization: Bearer em todas as requisições subsequentes
+.
+Verificação sem Estado (Stateless): O servidor ou API verifica apenas a assinatura digital do JWT usando uma chave secreta. Se a assinatura for válida e o token não tiver expirado, o acesso é concedido sem necessidade de consulta extra ao banco de dados de sessões
+.
+Checagem de Escopos: A API verifica se o token possui os "escopos" (permissões) necessários para realizar aquela ação específica (princípio do menor privilégio)
+.
+3. Fluxo de Login Social (OAuth e OpenID Connect)
+Redirecionamento Protegido: O app redireciona o usuário para o provedor (ex: Google) enviando um parâmetro state (contra ataques CSRF) e, no caso de apps móveis, um code_challenge (PKCE)
+.
+Autorização Delegada: O usuário faz login no provedor e concede permissão. O provedor devolve um código de autorização temporário para o app
+.
+Troca de Código por Tokens: O back-end do app troca esse código diretamente com o servidor do provedor por tokens de acesso e um ID Token (um JWT que contém os dados de identidade como nome e foto)
+.
+4. Ciclo de Vida e Renovação
+Expiração: Quando o Access Token de 15 minutos vence, a requisição do usuário falha
+.
+Renovação (Refresh): O cliente usa o Refresh Token para pedir um novo par de tokens. Através da rotação de tokens, o Refresh Token antigo é invalidado e um novo é emitido, garantindo segurança contínua
+.
+Este fluxo garante que o sistema seja escalável (via JWT), seguro (via Hashing e MFA) e ofereça uma boa experiência ao usuário (via Refresh Tokens e Login Social)

--- a/docs/Estruturas/Diretrizes para Nomenclatura e Estrutura de Projetos de Software.txt
+++ b/docs/Estruturas/Diretrizes para Nomenclatura e Estrutura de Projetos de Software.txt
@@ -1,0 +1,100 @@
+Com base nas fontes fornecidas, podemos extrair diretrizes e princípios importantes para nomear pastas e arquivos, além de definir as raízes principais da estrutura de um software ou aplicativo. As fontes abordam isso tanto de uma perspectiva de arquitetura de alto nível quanto de implementação prática, especialmente em contextos como Java e Python.
+A seguir, apresento uma resposta estruturada que combina esses conceitos para orientá-lo na nomeação e organização do seu projeto.
+1. A Estrutura Deve "Gritar" o Domínio do Negócio
+A diretriz mais importante é que a estrutura de alto nível do seu aplicativo deve revelar seu propósito, não as ferramentas ou frameworks que você está usando
+. Quando alguém olha a estrutura de pastas principal, a primeira impressão deve ser "Ah, este é um sistema de saúde" ou "Este é um sistema de vendas de vídeos", e não "Ah, este é um projeto em Rails"
+.
+Isso significa que as raízes principais (pastas no nível mais alto) devem refletir os conceitos do seu negócio (o domínio).
+2. Organização de Pastas (Pacotes)
+As fontes descrevem diferentes abordagens para organizar o código em pastas ou pacotes. A escolha ideal depende do estágio e da complexidade do projeto
+.
+Abordagens Comuns:
+Pacote por Camada (Horizontal - Package by Layer):
+Como funciona: Agrupa o código com base na sua função técnica
+.
+Nomes de Pastas (Raízes): web, services, repositories, data, ui
+.
+Vantagem: É uma forma rápida de começar um projeto, sem muita complexidade
+.
+Desvantagem: A estrutura não "grita" o domínio do negócio; projetos de domínios diferentes acabam parecendo muito similares
+. Com o crescimento do projeto, ter apenas alguns "baldes" grandes de código se torna insuficiente
+.
+Pacote por Funcionalidade (Vertical - Package by Feature):
+Como funciona: Agrupa verticalmente todo o código relacionado a uma funcionalidade de negócio em uma única pasta
+.
+Nomes de Pastas (Raízes): orders, users, products
+.
+Vantagem: A organização do código de alto nível agora revela algo sobre o domínio do negócio, e é mais fácil encontrar todo o código relacionado a uma funcionalidade específica
+.
+Desvantagem: Embora melhor que a abordagem por camada, ainda pode levar a um acoplamento indesejado se não for implementada com cuidado
+.
+Pacote por Componente (Package by Component):
+Como funciona: É uma abordagem híbrida que agrupa a lógica de negócios e o código de persistência de uma funcionalidade em um único componente, expondo uma interface bem definida
+. A UI é mantida separada
+.
+Nomes de Pastas (Raízes): A estrutura poderia ser:
+app/ (para a camada de UI, como controllers da web)
+components/
+orders/ (contém OrdersComponent e sua implementação)
+users/
+Vantagem: Encapsula melhor os detalhes de implementação e permite que o compilador ajude a reforçar a arquitetura, evitando que, por exemplo, um Controller acesse um Repository diretamente
+.
+Estrutura Recomendada para Código-fonte:
+Use uma pasta src: É uma prática recomendada colocar todo o código-fonte do seu pacote dentro de uma pasta src
+. Isso evita vários bugs comuns, como executar testes na versão local do código em vez da instalada
+.
+Exemplo de estrutura raiz:
+3. Nomenclatura de Arquivos e Classes
+As fontes fornecem diretrizes claras sobre como nomear arquivos, classes e métodos para garantir clareza e manutenibilidade.
+Nomenclatura de Classes:
+Use substantivos: Classes e objetos devem ter nomes de substantivos ou frases nominais, como Customer, WikiPage, Account
+.
+Seja específico e evite abreviações: Nomes como Processor, Manager ou Data são ambíguos e devem ser evitados
+.
+Convenção para Interfaces e Implementações:
+Evite prefixos como I para interfaces (ex: IShapeFactory)
+. Uma interface é um tipo, e sua implementação é um detalhe.
+Nomeie a implementação com um sufixo que a descreva, como JdbcOrdersRepository ou InMemoryNewsRepository
+. Se não houver um nome melhor, use Default como prefixo para a implementação (ex: DefaultNewsRepository)
+.
+Nomenclatura de Métodos/Funções:
+Use verbos: Métodos devem ter nomes de verbos ou frases verbais, como postPayment, deletePage, save
+.
+Padrão para acesso, alteração e predicados: Use get, set e is como prefixos de acordo com o padrão javabean
+.
+Convenção para Casos de Uso (Use Cases): Siga o padrão verbo no presente + substantivo/o que + UseCase
+. Exemplos: FormatDateUseCase, GetLatestNewsWithAuthorsUseCase
+.
+Nomenclatura de Variáveis:
+Seja claro e explícito: Nomes de variáveis devem revelar a intenção. Um nome de uma única letra só é aceitável para variáveis locais dentro de métodos curtos, como em laços (i, j)
+.
+Use nomes do domínio do problema: Use a terminologia do domínio do negócio nos nomes de variáveis, funções e classes. Isso torna o código mais fácil de entender para quem conhece o domínio
+.
+Raízes Principais de um Projeto
+Com base nos princípios de arquitetura e nas práticas de empacotamento, as raízes principais do seu projeto poderiam se assemelhar a esta estrutura:
+nome-do-projeto/
+├── docs/                      # Documentação do projeto [27]
+├── public/                    # Ativos estáticos (ex: workers de JS) [28]
+├── src/                       # Código-fonte da aplicação [18]
+│   ├── main/                  # Ponto de entrada e configuração (o "detalhe final") [29, 30]
+│   ├── ui/                    # Camada de UI (Controllers, Views, Presenters) [31]
+│   │   ├── orders/
+│   │   └── users/
+│   ├── domain/                # Camada de domínio (opcional para lógica complexa/reutilizável) [32, 33]
+│   │   └── usecases/
+│   │       ├── GetOrdersUseCase.js
+│   │       └── FormatDateUseCase.js
+│   └── data/                  # Camada de dados (Repositórios, fontes de dados) [8]
+│       ├── repositories/
+│       │   ├── OrdersRepository.js
+│       │   └── UsersRepository.js
+│       └── models/
+├── tests/                     # Testes [27]
+├── .gitignore                 # Arquivos a serem ignorados pelo Git
+├── LICENSE                    # Arquivo de licença [27]
+├── package.json               # ou pyproject.toml para Python [34]
+└── README.md                  # Descrição do projeto [27]
+Esta estrutura é um exemplo híbrido. A separação em ui, domain e data segue a arquitetura em camadas
+, enquanto a subdivisão dentro de ui (por exemplo, orders/, users/) reflete a organização por funcionalidade
+. O mais importante é que essa estrutura mantém os detalhes (como a UI e o acesso a dados) separados das regras de negócio, permitindo a evolução e manutenção do sistema com menor custo
+.

--- a/docs/Estruturas/Projeto de Software com Arquitetura Limpa.txt
+++ b/docs/Estruturas/Projeto de Software com Arquitetura Limpa.txt
@@ -1,0 +1,92 @@
+Com certeza! Com base em todo o nosso histórico de conversas e nas fontes fornecidas, criei um prompt abrangente que pode ser usado para gerar a estrutura completa de um novo projeto de software.
+Este prompt foi projetado para ser usado com uma IA assistente de programação (como o GitHub Copilot, ChatGPT com foco em código, Gemini, etc.) ou como um guia detalhado para uma equipe de desenvolvimento. Ele incorpora os princípios da Arquitetura Limpa, SOLID, organização de pacotes e convenções de nomenclatura que discutimos.
+--------------------------------------------------------------------------------
+Prompt Detalhado para Geração e Organização de Projeto de Software
+Atue como um Arquiteto de Software Sênior e Engenheiro Principal.
+Seu objetivo é gerar a estrutura completa para um novo projeto de software, seguindo os princípios da Arquitetura Limpa (Clean Architecture) de Robert C. Martin e as melhores práticas de desenvolvimento. O projeto deve ser robusto, testável, de fácil manutenção e escalável
+. A estrutura deve "gritar" o domínio de negócio do projeto, e não os frameworks utilizados
+.
+1. Contexto do Projeto:
+Nome do Projeto: [Insira o nome do projeto aqui, ex: "Sistema de Gestão de Catálogo de Vídeos"]
+Linguagem Principal: [Insira a linguagem, ex: "Kotlin", "Python", "Java", "JavaScript/TypeScript"]
+Framework Principal (se aplicável, será tratado como um detalhe): [Insira o framework, ex: "Spring Boot", "Next.js", "Django"]
+Breve Descrição do Domínio: [Descreva em 1-2 frases o propósito do projeto, ex: "Uma plataforma para autores enviarem e venderem vídeos educacionais para indivíduos e empresas."]
+.
+2. Geração da Estrutura de Diretórios (Pastas):
+Crie a seguinte estrutura de diretórios, priorizando a abordagem de "Pacote por Componente" ou "Pacote por Funcionalidade" para que a organização reflita o domínio do negócio
+. Use nomes em minúsculas e separados por hífen para diretórios de alto nível e nomes de pacotes padronizados para o código-fonte.
+[nome-do-projeto]/
+|-- .gitignore               # Arquivo para ignorar artefatos de build, dependências e arquivos de IDE.
+|-- pyproject.toml           # ou build.gradle, package.json, etc., dependendo da linguagem.
+|-- README.md                # Descrição inicial do projeto, como configurar e executar.
+|-- LICENSE                  # Arquivo de licença (ex: MIT, Apache 2.0).
+|
+|-- docs/                    # Documentação do projeto (decisões de arquitetura, guias de estilo, etc.).
+|
+|-- src/                     # Diretório raiz para todo o código-fonte [14].
+|   |-- main/                # Ponto de entrada e configuração do sistema. O componente "mais sujo" [15-17].
+|   |
+|   |-- core/                # Ou 'domain'. O coração do sistema. Contém as regras de negócio.
+|   |   |-- entities/        # Modelos de domínio puros. Regras de negócio críticas [18, 19].
+|   |   |-- usecases/        # Regras de negócio específicas da aplicação [18, 20, 21].
+|   |   |-- ports/           # ou 'gateways'/'repositories'. Interfaces (abstrações) para a camada de dados.
+|   |
+|   |-- infrastructure/      # Detalhes de implementação, frameworks e drivers [22].
+|   |   |-- web/             # Camada de UI. Controllers, Presenters, Views, etc. [23].
+|   |   |-- data/            # Camada de Dados. Implementações de repositórios, ORMs, acesso a BD [24].
+|   |   |-- config/          # Configuração de frameworks (ex: injeção de dependência).
+|
+|-- tests/                   # Testes. A estrutura aqui deve espelhar a de 'src' [25, 26].
+|   |-- unit/
+|   |-- integration/
+|   |-- e2e/
+
+3. Princípios e Regras a Serem Aplicados:
+Ao gerar o código inicial (placeholders/stubs) para cada camada/componente, siga estritamente estes princípios:
+A Regra da Dependência (The Dependency Rule): As dependências do código-fonte devem sempre apontar para dentro, das camadas externas (detalhes) para as camadas internas (políticas/regras de negócio)
+. O core/domain não deve saber nada sobre infrastructure
+.
+Princípios SOLID
+:
+SRP (Responsabilidade Única): Separe o código com base nos "atores" (fontes de mudança)
+. Por exemplo, a lógica de cálculo de pagamento deve estar separada da lógica de relatório de horas
+.
+OCP (Aberto-Fechado): A estrutura deve ser extensível (adicionando novos casos de uso ou funcionalidades) sem modificar o código existente do núcleo
+.
+LSP (Substituição de Liskov): As implementações de interfaces (por exemplo, diferentes repositórios) devem ser substituíveis sem quebrar a lógica de alto nível
+.
+ISP (Segregação de Interface): Crie interfaces específicas para os clientes, evitando que eles dependam de métodos que não usam
+.
+DIP (Inversão de Dependência): Módulos de alto nível não devem depender de módulos de baixo nível. Ambos devem depender de abstrações
+. Use interfaces (ports) no core para serem implementadas pelos adapters na infrastructure.
+Independência de Detalhes: A arquitetura deve permitir que decisões sobre banco de dados
+, web framework
+ e outras ferramentas sejam adiadas e tratadas como plugins
+.
+4. Convenções de Nomenclatura:
+Aplique as seguintes convenções de nomenclatura em todos os arquivos e classes gerados
+:
+Classes/Entidades: Use substantivos claros e do domínio do negócio (ex: Video, UserLicense, PurchaseOrder)
+.
+Casos de Uso (Use Cases): Use o padrão VerboNoPresente + Substantivo + UseCase (ex: PurchaseVideoUseCase, ListAvailableVideosUseCase)
+.
+Interfaces (Ports): Use nomes que descrevam o contrato (ex: VideoRepository, PaymentGateway)
+.
+Implementações (Adapters): Seja específico sobre a tecnologia usada (ex: MongoVideoRepository, StripePaymentGateway). Se for uma implementação padrão, use Default como prefixo ou a tecnologia como sufixo
+.
+Métodos/Funções: Use verbos ou frases verbais (ex: calculatePrice, saveUser)
+.
+5. Geração de Código de Exemplo (Stubs):
+Para o domínio de [Insira o Domínio do Projeto aqui], gere exemplos de arquivos para as seguintes funcionalidades:
+Funcionalidade 1: "Visualizar Catálogo de Vídeos"
+src/core/entities/Video.kt: Uma data class/struct com id, title, description.
+src/core/usecases/ListAvailableVideosUseCase.kt: Uma classe que depende de uma interface VideoRepository e retorna uma lista de Video.
+src/core/ports/VideoRepository.kt: Uma interface com um método fun findAvailable(): List<Video>.
+src/infrastructure/data/InMemoryVideoRepository.kt: Uma implementação da interface VideoRepository que usa uma lista em memória para facilitar os testes.
+src/infrastructure/web/VideoController.kt: Um controller que invoca o ListAvailableVideosUseCase e retorna os dados (sem se acoplar diretamente a um framework web).
+6. Testabilidade:
+Gere um exemplo de teste de unidade para o ListAvailableVideosUseCase. O teste deve usar uma implementação falsa (fake) ou um mock do VideoRepository para demonstrar que a lógica de negócio pode ser testada de forma isolada, sem a necessidade de banco de dados ou UI
+.
+Conclusão do Prompt:
+Ao final, forneça um resumo de como a estrutura gerada atende aos requisitos de uma arquitetura limpa, destacando como a separação de conceitos foi alcançada e como ela permite a independência de desenvolvimento, implantação e manutenção.
+--------------------------------------------------------------------------------

--- a/docs/Estruturas/Relatório de Arquitetura Análise Comparativa de Autenticação Stateful vs Stateless.txt
+++ b/docs/Estruturas/Relatório de Arquitetura Análise Comparativa de Autenticação Stateful vs Stateless.txt
@@ -1,0 +1,115 @@
+Relatório de Arquitetura: Análise Comparativa de Autenticação Stateful vs. Stateless
+1. Fundamentos da Identidade Digital e Segurança de Acesso
+No ecossistema de arquitetura de software moderna, a segurança robusta estabelece-se na distinção rigorosa entre Autenticação e Autorização. Para ilustrar esse conceito a stakeholders, utilizamos a analogia da portaria de um prédio comercial: a Autenticação é o momento em que você apresenta um documento oficial para provar quem você é; a Autorização ocorre quando, após identificado, você recebe um crachá que define especificamente a quais andares ou salas tem permissão para acessar. Primeiro, o sistema valida a identidade; depois, gerencia os privilégios.
+A proteção da identidade começa no armazenamento de credenciais. Senhas jamais devem habitar o banco de dados em texto puro, sendo processadas por funções de hash. Contudo, a escolha do algoritmo é crítica. Funções rápidas como o SHA256 são inadequadas para senhas, pois uma GPU moderna consegue processar cerca de 1 bilhão de hashes por segundo, permitindo ataques de força bruta massivos em tempo recorde. Arquiteturas resilientes exigem funções "lentas" com work factor ajustável, como BCrypt ou Argon 2, que introduzem um custo computacional deliberado para tornar ataques inviáveis. Além disso, a implementação de um salt (valor aleatório único por usuário) é mandatória para garantir que senhas idênticas gerem hashes distintos, neutralizando o uso de rainbow tables.
+Para mitigar vetores de ataque na camada de interface, como a enumeração de usuários, as mensagens de erro devem ser invariavelmente genéricas (ex: "E-mail ou senha incorretos"). Adicionalmente, deve-se implementar rate limiting rigoroso por IP e por conta, bloqueando tentativas automatizadas após X falhas consecutivas. Estas medidas protegem a fase de login, mas uma vez estabelecida a identidade, surge a necessidade técnica de manter esse estado durante a navegação do usuário.
+2. Autenticação Stateful: Sessões Baseadas em Servidor
+A autenticação Stateful representa a abordagem tradicional de "memória" do servidor, sendo a escolha estratégica para aplicações web monolíticas que exigem controle granular e centralizado do estado do usuário.
+Neste modelo, o servidor mantém um registro da sessão e transmite um identificador único ao cliente via Cookies. Para garantir a integridade deste transporte, é imperativo configurar as seguintes flags de segurança:
+httpOnly: Bloqueia o acesso ao cookie via JavaScript, mitigando o roubo de sessões por ataques de Cross-Site Scripting (XSS).
+Secure: Obriga o envio do cookie exclusivamente através de conexões criptografadas (HTTPS).
+SameSite (Strict/Lax): Previne que o cookie seja enviado em requisições de sites terceiros, oferecendo uma defesa robusta contra Cross-Site Request Forgery (CSRF).
+Do ponto de vista de riscos, a arquitetura deve prevenir a Session Fixation através da regeneração obrigatória do ID de sessão imediatamente após a autenticação. É igualmente vital que a troca de senha force a invalidação de todas as sessões ativas no servidor. Em cenários de alta disponibilidade com múltiplos servidores atrás de um load balancer, a escalabilidade das sessões exige uma camada de estado compartilhada. A solução técnica recomendada é o uso de bancos de dados em memória, como o Redis, garantindo que qualquer nó da infraestrutura reconheça o usuário sem latência perceptível. Embora eficiente, a dependência de um estado centralizado motiva a exploração de modelos descentralizados como o JWT.
+3. Autenticação Stateless: Arquitetura JSON Web Token (JWT)
+A arquitetura Stateless elimina a necessidade de consultas constantes a um banco de dados de sessões, transferindo a responsabilidade da validação para a verificação criptográfica. O JWT (JSON Web Token) é o padrão desta abordagem, permitindo que o servidor seja "agnóstico ao estado".
+A anatomia de um JWT divide-se em:
+Header: Especifica o algoritmo de assinatura.
+Payload: Contém as claims (dados do usuário e metadados). Aviso de Segurança: O payload é apenas codificado em Base64; qualquer informação sensível ali depositada pode ser lida por terceiros.
+Signature: Garante que o conteúdo não foi adulterado.
+A segurança do token reside na criptografia. Algoritmos simétricos (HMAC) utilizam uma única chave secreta (que exige ao menos 256 bits de entropia), enquanto algoritmos assimétricos (RSA/ECDSA) utilizam um par de chaves pública/privada. Para microsserviços, o uso de chaves assimétricas é uma vantagem estratégica: apenas o servidor de autenticação possui a chave privada para assinar, enquanto os demais serviços utilizam apenas a chave pública para validar o token. Nota Crítica de Arquitetura: É obrigatório validar as claims iss (issuer - quem emitiu) e aud (audience - para quem se destina) para evitar que tokens emitidos para o "Serviço A" sejam indevidamente aceitos pelo "Serviço B".
+Quanto ao armazenamento em aplicações Web, o "padrão ouro" é o uso de Cookies HttpOnly, pois o Local Storage é vulnerável a vazamentos via XSS. Para gerir a revogação, utilizamos Access Tokens de curta duração e Refresh Tokens com rotação (invalidando o antigo a cada uso), mitigando o risco de tokens persistentes em mãos erradas. Essa estrutura flexível sustenta a onipresença do JWT em ecossistemas de APIs modernas.
+4. Análise Comparativa e Tomada de Decisão
+A decisão arquitetural entre Stateful e Stateless exige um equilíbrio entre controle operacional e escalabilidade horizontal.
+Critério
+Sessões (Stateful)
+JWT (Stateless)
+Escalabilidade
+Complexa (requer Redis/Estado compartilhado)
+Alta (independência entre servidores)
+Facilidade de Revogação
+Instantânea (centralizada no servidor)
+Complexa (depende de expiração ou listas de bloqueio)
+Complexidade
+Baixa (nativa em frameworks)
+Moderada (gestão de chaves e rotação)
+Overhead de Rede
+Baixo (ID de sessão curto)
+Moderado (Payload e assinatura em cada request)
+Direcionamento Estratégico:
+Sessões: Recomendadas para aplicações web tradicionais e sistemas onde a revogação imediata de acesso é um requisito de negócio inegociável.
+JWT: Ideal para arquiteturas de microsserviços, APIs mobile e integrações com terceiros.
+Híbrido: Comum em infraestruturas complexas onde a sessão atende o front-end e o JWT protege a comunicação entre serviços internos.
+5. Ecossistemas Modernos: OAuth 2.0, OpenID Connect e Passkeys
+A segurança evoluiu para modelos de autorização delegada. O OAuth 2.0 é o framework que permite a um serviço acessar dados em outro sob o Princípio do Menor Privégio, utilizando escopos limitados. Ele define quatro papéis essenciais: Resource Owner (usuário), Client (aplicativo), Authorization Server (ex: Google) e Resource Server (API de dados).
+O fluxo mais seguro é o Authorization Code com as seguintes proteções:
+PKCE (Proof Key for Code Exchange): Mandatário para aplicações móveis e SPAs, garantindo que o interceptador do código não consiga trocá-lo por um token.
+Parâmetro state: Protege contra CSRF durante o redirecionamento.
+OpenID Connect (OIDC): Camada de identidade que introduz o ID Token e o parâmetro nonce, fundamental para impedir ataques de replay ao garantir que o token é único para aquela sessão de login.
+Na vanguarda, as Passkeys utilizam criptografia de chave pública para eliminar senhas. Através do mecanismo challenge-signature, o dispositivo assina um desafio do servidor com uma chave privada protegida biometricamente. Elas são imunes a phishing devido ao domain binding: o dispositivo reconhece que o domínio "G00gle.com" (com zeros) não é o "Google.com" legítimo e recusa a assinatura.
+Para defesa em profundidade, o MFA via TOTP é superior ao SMS (vulnerável a SIM Swap), funcionando offline por ser um cálculo matemático (Segredo + Tempo / 30 + HMAC). Operações críticas devem exigir Step-up Authentication, solicitando o segundo fator novamente antes da execução.
+6. Conclusão e Recomendações de Segurança de Infraestrutura
+A segurança resiliente é uma postura contínua e em camadas. A escolha da arquitetura de tokens ou sessões é apenas o alicerce de uma estratégia que deve incluir a sanitização rigorosa de inputs e a configuração correta da rede.
+Checklist de Segurança: Diretrizes de Implementação
+[ ] Prevenção de Injeção: Utilize exclusivamente queries parametrizadas; jamais concatene inputs no SQL.
+[ ] Gestão de Redirecionamento: Proiba wildcards em URIs de redirecionamento; valide o retorno caractere por caractere (evite Open Redirects).
+[ ] Configuração de CORS: Defina origens explícitas e permitidas; evite o uso de * quando credenciais estiverem envolvidas.
+[ ] Fluxo de Recuperação de Senha: Tokens de reset devem ser aleatórios (alta entropia), de uso único, com curtíssima duração e nunca baseados em dados previsíveis como Base64 do ID do usuário.
+[ ] Segredos de Assinatura: Chaves HMAC devem possuir no mínimo 256 bits de entropia e ser armazenadas em cofres de segredos ou variáveis de ambiente, nunca no código-fonte.
+Ao final, a integridade de qualquer sistema depende da capacidade de invalidar sessões e tokens em eventos críticos, garantindo que a confiança estabelecida no login permaneça válida e protegida contra a evolução constante das ameaças.# Relatório de Arquitetura: Análise Comparativa de Autenticação Stateful vs. Stateless
+1. Fundamentos da Identidade Digital e Segurança de Acesso
+No ecossistema de arquitetura de software moderna, a segurança robusta estabelece-se na distinção rigorosa entre Autenticação e Autorização. Para ilustrar esse conceito a stakeholders, utilizamos a analogia da portaria de um prédio comercial: a Autenticação é o momento em que você apresenta um documento oficial para provar quem você é; a Autorização ocorre quando, após identificado, você recebe um crachá que define especificamente a quais andares ou salas tem permissão para acessar. Primeiro, o sistema valida a identidade; depois, gerencia os privilégios.
+A proteção da identidade começa no armazenamento de credenciais. Senhas jamais devem habitar o banco de dados em texto puro, sendo processadas por funções de hash. Contudo, a escolha do algoritmo é crítica. Funções rápidas como o SHA256 são inadequadas para senhas, pois uma GPU moderna consegue processar cerca de 1 bilhão de hashes por segundo, permitindo ataques de força bruta massivos em tempo recorde. Arquiteturas resilientes exigem funções "lentas" com work factor ajustável, como BCrypt ou Argon 2, que introduzem um custo computacional deliberado para tornar ataques inviáveis. Além disso, a implementação de um salt (valor aleatório único por usuário) é mandatória para garantir que senhas idênticas gerem hashes distintos, neutralizando o uso de rainbow tables.
+Para mitigar vetores de ataque na camada de interface, como a enumeração de usuários, as mensagens de erro devem ser invariavelmente genéricas (ex: "E-mail ou senha incorretos"). Adicionalmente, deve-se implementar rate limiting rigoroso por IP e por conta, bloqueando tentativas automatizadas após X falhas consecutivas. Estas medidas protegem a fase de login, mas uma vez estabelecida a identidade, surge a necessidade técnica de manter esse estado durante a navegação do usuário.
+2. Autenticação Stateful: Sessões Baseadas em Servidor
+A autenticação Stateful representa a abordagem tradicional de "memória" do servidor, sendo a escolha estratégica para aplicações web monolíticas que exigem controle granular e centralizado do estado do usuário.
+Neste modelo, o servidor mantém um registro da sessão e transmite um identificador único ao cliente via Cookies. Para garantir a integridade deste transporte, é imperativo configurar as seguintes flags de segurança:
+httpOnly: Bloqueia o acesso ao cookie via JavaScript, mitigando o roubo de sessões por ataques de Cross-Site Scripting (XSS).
+Secure: Obriga o envio do cookie exclusivamente através de conexões criptografadas (HTTPS).
+SameSite (Strict/Lax): Previne que o cookie seja enviado em requisições de sites terceiros, oferecendo uma defesa robusta contra Cross-Site Request Forgery (CSRF).
+Do ponto de vista de riscos, a arquitetura deve prevenir a Session Fixation através da regeneração obrigatória do ID de sessão imediatamente após a autenticação. É igualmente vital que a troca de senha force a invalidação de todas as sessões ativas no servidor. Em cenários de alta disponibilidade com múltiplos servidores atrás de um load balancer, a escalabilidade das sessões exige uma camada de estado compartilhada. A solução técnica recomendada é o uso de bancos de dados em memória, como o Redis, garantindo que qualquer nó da infraestrutura reconheça o usuário sem latência perceptível. Embora eficiente, a dependência de um estado centralizado motiva a exploração de modelos descentralizados como o JWT.
+3. Autenticação Stateless: Arquitetura JSON Web Token (JWT)
+A arquitetura Stateless elimina a necessidade de consultas constantes a um banco de dados de sessões, transferindo a responsabilidade da validação para a verificação criptográfica. O JWT (JSON Web Token) é o padrão desta abordagem, permitindo que o servidor seja "agnóstico ao estado".
+A anatomia de um JWT divide-se em:
+Header: Especifica o algoritmo de assinatura.
+Payload: Contém as claims (dados do usuário e metadados). Aviso de Segurança: O payload é apenas codificado em Base64; qualquer informação sensível ali depositada pode ser lida por terceiros.
+Signature: Garante que o conteúdo não foi adulterado.
+A segurança do token reside na criptografia. Algoritmos simétricos (HMAC) utilizam uma única chave secreta (que exige ao menos 256 bits de entropia), enquanto algoritmos assimétricos (RSA/ECDSA) utilizam um par de chaves pública/privada. Para microsserviços, o uso de chaves assimétricas é uma vantagem estratégica: apenas o servidor de autenticação possui a chave privada para assinar, enquanto os demais serviços utilizam apenas a chave pública para validar o token. Nota Crítica de Arquitetura: É obrigatório validar as claims iss (issuer - quem emitiu) e aud (audience - para quem se destina) para evitar que tokens emitidos para o "Serviço A" sejam indevidamente aceitos pelo "Serviço B".
+Quanto ao armazenamento em aplicações Web, o "padrão ouro" é o uso de Cookies HttpOnly, pois o Local Storage é vulnerável a vazamentos via XSS. Para gerir a revogação, utilizamos Access Tokens de curta duração e Refresh Tokens com rotação (invalidando o antigo a cada uso), mitigando o risco de tokens persistentes em mãos erradas. Essa estrutura flexível sustenta a onipresença do JWT em ecossistemas de APIs modernas.
+4. Análise Comparativa e Tomada de Decisão
+A decisão arquitetural entre Stateful e Stateless exige um equilíbrio entre controle operacional e escalabilidade horizontal.
+Critério
+Sessões (Stateful)
+JWT (Stateless)
+Escalabilidade
+Complexa (requer Redis/Estado compartilhado)
+Alta (independência entre servidores)
+Facilidade de Revogação
+Instantânea (centralizada no servidor)
+Complexa (depende de expiração ou listas de bloqueio)
+Complexidade
+Baixa (nativa em frameworks)
+Moderada (gestão de chaves e rotação)
+Overhead de Rede
+Baixo (ID de sessão curto)
+Moderado (Payload e assinatura em cada request)
+Direcionamento Estratégico:
+Sessões: Recomendadas para aplicações web tradicionais e sistemas onde a revogação imediata de acesso é um requisito de negócio inegociável.
+JWT: Ideal para arquiteturas de microsserviços, APIs mobile e integrações com terceiros.
+Híbrido: Comum em infraestruturas complexas onde a sessão atende o front-end e o JWT protege a comunicação entre serviços internos.
+5. Ecossistemas Modernos: OAuth 2.0, OpenID Connect e Passkeys
+A segurança evoluiu para modelos de autorização delegada. O OAuth 2.0 é o framework que permite a um serviço acessar dados em outro sob o Princípio do Menor Privégio, utilizando escopos limitados. Ele define quatro papéis essenciais: Resource Owner (usuário), Client (aplicativo), Authorization Server (ex: Google) e Resource Server (API de dados).
+O fluxo mais seguro é o Authorization Code com as seguintes proteções:
+PKCE (Proof Key for Code Exchange): Mandatário para aplicações móveis e SPAs, garantindo que o interceptador do código não consiga trocá-lo por um token.
+Parâmetro state: Protege contra CSRF durante o redirecionamento.
+OpenID Connect (OIDC): Camada de identidade que introduz o ID Token e o parâmetro nonce, fundamental para impedir ataques de replay ao garantir que o token é único para aquela sessão de login.
+Na vanguarda, as Passkeys utilizam criptografia de chave pública para eliminar senhas. Através do mecanismo challenge-signature, o dispositivo assina um desafio do servidor com uma chave privada protegida biometricamente. Elas são imunes a phishing devido ao domain binding: o dispositivo reconhece que o domínio "G00gle.com" (com zeros) não é o "Google.com" legítimo e recusa a assinatura.
+Para defesa em profundidade, o MFA via TOTP é superior ao SMS (vulnerável a SIM Swap), funcionando offline por ser um cálculo matemático (Segredo + Tempo / 30 + HMAC). Operações críticas devem exigir Step-up Authentication, solicitando o segundo fator novamente antes da execução.
+6. Conclusão e Recomendações de Segurança de Infraestrutura
+A segurança resiliente é uma postura contínua e em camadas. A escolha da arquitetura de tokens ou sessões é apenas o alicerce de uma estratégia que deve incluir a sanitização rigorosa de inputs e a configuração correta da rede.
+Checklist de Segurança: Diretrizes de Implementação
+[ ] Prevenção de Injeção: Utilize exclusivamente queries parametrizadas; jamais concatene inputs no SQL.
+[ ] Gestão de Redirecionamento: Proiba wildcards em URIs de redirecionamento; valide o retorno caractere por caractere (evite Open Redirects).
+[ ] Configuração de CORS: Defina origens explícitas e permitidas; evite o uso de * quando credenciais estiverem envolvidas.
+[ ] Fluxo de Recuperação de Senha: Tokens de reset devem ser aleatórios (alta entropia), de uso único, com curtíssima duração e nunca baseados em dados previsíveis como Base64 do ID do usuário.
+[ ] Segredos de Assinatura: Chaves HMAC devem possuir no mínimo 256 bits de entropia e ser armazenadas em cofres de segredos ou variáveis de ambiente, nunca no código-fonte.
+Ao final, a integridade de qualquer sistema depende da capacidade de invalidar sessões e tokens em eventos críticos, garantindo que a confiança estabelecida no login permaneça válida e protegida contra a evolução constante das ameaças.

--- a/docs/Estruturas/Segurança e Controle de Dados no Supabase RLS.txt
+++ b/docs/Estruturas/Segurança e Controle de Dados no Supabase RLS.txt
@@ -1,0 +1,14 @@
+No contexto do Supabase, a Segurança de Nível de Linha (Row Level Security - RLS) atua como uma camada crítica de proteção que garante que os usuários acessem apenas os dados que estão autorizados a ver
+. Em uma plataforma de Back-end as a Service (BaaS) onde o cliente muitas vezes interage diretamente com o banco de dados via SDK, o RLS é o que impede que um usuário mal-intencionado acesse informações de terceiros
+.
+De acordo com as fontes, a relação entre o RLS e as funcionalidades do Supabase, especialmente o Realtime, baseia-se nos seguintes pontos:
+Integração com o Realtime: Uma das características mais robustas mencionadas é que o recurso de tempo real respeita rigorosamente as políticas de RLS
+. Isso significa que, mesmo que uma tabela esteja transmitindo atualizações em broadcast, o sistema filtra essas mensagens antes que elas cheguem ao cliente
+.
+Controle Baseado em Identidade: A autorização para receber ou visualizar um dado é determinada pelo token de autenticação (JWT) do usuário
+. É através desse token que o Supabase identifica quem é o solicitante e aplica as regras de permissão "legal" definidas no banco de dados
+.
+Privacidade e Filtragem: Graças ao RLS, um usuário só receberá notificações de inserção, atualização ou exclusão de linhas se ele tiver permissão explícita para visualizar esses registros específicos
+. Isso evita o vazamento de dados sensíveis em aplicações multiusuário
+.
+Para facilitar a compreensão, imagine que o banco de dados é um grande prédio de escritórios. Sem o RLS, qualquer pessoa que entrasse no prédio poderia abrir qualquer gaveta de qualquer mesa. Com o RLS, é como se cada funcionário tivesse uma chave mestra eletrônica (o JWT) que só abre as portas das salas onde ele tem permissão para trabalhar. Mesmo que algo novo seja entregue no prédio (uma atualização em tempo real), o segurança só levará o pacote até você se a sua chave permitir a entrada naquela sala específica.

--- a/docs/Estruturas/Supabase Realtime Dinamismo e Sincronização em Tempo Real.txt
+++ b/docs/Estruturas/Supabase Realtime Dinamismo e Sincronização em Tempo Real.txt
@@ -1,0 +1,38 @@
+No contexto de uma introdução ao Supabase, que é uma plataforma de Back-end as a Service (BaaS) de código aberto e alternativa ao Firebase, os recursos em tempo real (Realtime) são pilares fundamentais para a criação de aplicações dinâmicas e interativas
+.
+De acordo com as fontes, aqui estão os pontos principais sobre como o Realtime funciona e é implementado:
+1. O que é o Recurso de Tempo Real?
+O Supabase permite que as aplicações recebam atualizações instantâneas sempre que houver modificações nas tabelas do banco de dados (como inserções, alterações ou exclusões)
+. Isso elimina a necessidade de o usuário atualizar a página manualmente para ver novos dados, como em um dashboard de vendas que precisa refletir novos negócios no momento em que são fechados
+.
+2. A Extensão "Postgres Changes"
+O funcionamento do tempo real no Supabase é baseado em extensões, sendo a principal o "Postgres Changes"
+. Esta extensão escuta as alterações ocorridas no banco de dados PostgreSQL (no qual o Supabase é construído) e as envia para os clientes conectados
+. Os desenvolvedores podem filtrar quais eventos desejam monitorar:
+INSERT: Novas linhas adicionadas
+.
+UPDATE: Alterações em linhas existentes
+.
+DELETE: Remoção de dados
+.
+* (Star): Todos os eventos acima simultaneamente
+.
+3. Configuração e Implementação
+Para que o recurso funcione, as fontes detalham um fluxo técnico específico:
+Habilitação na Tabela: O recurso de "Realtime" deve ser ativado manualmente nas configurações da tabela específica dentro do painel do Supabase para que ela comece a transmitir mudanças
+.
+Uso do SDK: No front-end, utiliza-se a biblioteca supabase-js para criar uma conexão
+.
+Assinatura (Subscription): O código utiliza o método .channel() para definir um canal de comunicação e .on() para especificar que está ouvindo mudanças no Postgres
+.
+Integração com React: A configuração da assinatura é geralmente feita dentro do gancho useEffect, garantindo que o "radar" de monitoramento seja ligado assim que o componente for montado
+.
+4. Boas Práticas e Segurança
+Limpeza (Cleanup): É crucial implementar uma função de limpeza para se desinscrever (unsubscribe) do canal quando o componente for desmontado, evitando vazamentos de memória e assinaturas duplicadas
+.
+Segurança (RLS): O Realtime respeita as políticas de Segurança de Nível de Linha (Row Level Security - RLS)
+. Isso significa que um usuário só receberá atualizações em tempo real de dados que ele tem permissão legal para visualizar, baseando-se em seu token de autenticação (JWT)
+.
+As fontes utilizam uma metáfora útil para facilitar a compreensão: assinar atualizações em tempo real é como assinar uma revista ou um podcast
+. Assim que uma nova edição (ou dado) é publicada, ela é enviada automaticamente para o seu endereço (ou aplicação), sem que você precise ir buscá-la manualmente toda vez
+.

--- a/docs/Plano de Correção — Vulnerabilidades de Segurança.txt
+++ b/docs/Plano de Correção — Vulnerabilidades de Segurança.txt
@@ -1,0 +1,495 @@
+# Plano de Correção — Vulnerabilidades de Segurança
+
+Baseado na análise de 2026-05-01. Ordenado por prioridade.
+
+---
+
+## Descoberta importante durante a pesquisa
+
+> [!NOTE]
+> **Saldo/estoque JÁ é validado por triggers no banco** — não precisa de mudança.
+> - `validar_saldo_saida()` — impede saída com quantidade > estoque disponível (trigger BEFORE INSERT/UPDATE em `saidas`)
+> - `validar_cancelamento_entrada()` — impede cancelamento de entrada se gera estoque negativo (trigger BEFORE UPDATE em `entradas`)
+> - RPCs `rpc_entradas_create_full` e `rpc_saidas_create_full` executam via `buildUserClient(authToken)` (client com token do usuário), garantindo RLS
+>
+> **Isso remove o item 3 da lista de "críticos"** da análise anterior. Risco de saldo fica 🟢 Baixo.
+
+---
+
+## User Review Required
+
+> [!IMPORTANT]
+> **CORS whitelist** — preciso saber quais são os domínios de produção/staging do projeto. Ex: `https://api-estoque-xyz.vercel.app`. Posso extrair de `.env.vercel` ou você pode confirmar.
+
+> [!IMPORTANT]
+> **Rate limit para leitura** — expandir o rate limit para GETs adicionará latência (1 chamada RPC extra por request). Qual nível de agressividade deseja?
+> - **Opção A**: Rate limit apenas para rotas sensíveis (relatório, exportação, dashboard)
+> - **Opção B**: Rate limit global para todas as rotas (incluindo listagens normais)
+
+> [!IMPORTANT]
+> **Audit log** — criar tabela `audit_log` implica em migration nova no Supabase. Confirma que posso criar essa migration? Ela registraria TODAS as ações de create/update/delete com metadados.
+
+---
+
+## Proposed Changes
+
+### 1. 🔴 CORS Whitelist
+
+**Problema**: `cors.js` reflete qualquer `Origin` → aceita requisições cross-origin de qualquer domínio.
+
+**Solução**: Whitelist de origens via variável de ambiente `CORS_ALLOWED_ORIGINS`.
+
+#### [MODIFY] [cors.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/cors.js)
+
+```diff
++const ALLOWED_ORIGINS = new Set(
++  (process.env.CORS_ALLOWED_ORIGINS || '')
++    .split(',')
++    .map(o => o.trim())
++    .filter(Boolean)
++)
++
++const DEV_PATTERNS = [/^http:\/\/localhost(:\d+)?$/, /^http:\/\/127\.0\.0\.1(:\d+)?$/]
++
++const isAllowedOrigin = (origin) => {
++  if (!origin) return false
++  if (ALLOWED_ORIGINS.has(origin)) return true
++  if (process.env.NODE_ENV !== 'production') {
++    return DEV_PATTERNS.some(re => re.test(origin))
++  }
++  return false
++}
+
+ export async function cors(ctx) {
+   const { req, res } = ctx.raw || {}
+   if (!req || !res) return undefined
+
+-  const origin = req.headers?.origin || '*'
+-  res.setHeader('Access-Control-Allow-Origin', origin)
++  const origin = req.headers?.origin || ''
++  if (isAllowedOrigin(origin)) {
++    res.setHeader('Access-Control-Allow-Origin', origin)
++  }
+   res.setHeader('Vary', 'Origin')
+```
+
+**Variável de ambiente necessária**:
+- `CORS_ALLOWED_ORIGINS` — ex: `https://api-estoque-xyz.vercel.app,https://api-estoque-staging.vercel.app`
+- Configurar em Vercel Settings → Environment Variables
+
+---
+
+### 2. 🔴 Autorização por Permissão na API (Permission Guard)
+
+**Problema**: O middleware autentica o usuário (JWT válido), mas **não verifica se ele tem permissão** para a rota. Qualquer autenticado pode chamar qualquer endpoint.
+
+**Solução**: Novo middleware `permissionGuard` que mapeia rota → permissão e consulta `user_roles` / `user_permission_overrides` do usuário.
+
+#### [NEW] [permissionGuard.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/permissionGuard.js)
+
+```javascript
+import { supabaseAdmin } from '../supabaseClient.js'
+import { createHttpError } from '../http.js'
+
+// Mapa de rota da API → permission key(s) necessária(s)
+// Rotas não mapeadas aqui são abertas para qualquer autenticado
+const ROUTE_PERMISSIONS = {
+  // Pessoas
+  'POST /api/pessoas':                'cadastros.pessoas',
+  'PUT /api/pessoas':                 'cadastros.pessoas',
+  'GET /api/pessoas':                 'pessoas.read',
+  // ASO
+  'POST /api/aso':                    'pcsmo.controle_aso',
+  'PUT /api/aso':                     'pcsmo.controle_aso',
+  'POST /api/aso/register-exam':      'pcsmo.controle_aso',
+  'GET /api/aso':                     'pcsmo.controle_aso',
+  // Materiais
+  'POST /api/materiais':              'estoque.materiais',
+  'PUT /api/materiais':               'estoque.materiais',
+  // Acidentes
+  'POST /api/acidentes':              'acidentes.write',
+  'PUT /api/acidentes':               'acidentes.write',
+  'GET /api/acidentes':               'acidentes.read',
+  // Entradas
+  'POST /api/entradas':               'estoque.entradas',
+  'PUT /api/entradas':                'estoque.entradas',
+  'GET /api/entradas':                'estoque.entradas',
+  // Saídas
+  'POST /api/saidas':                 'estoque.saidas',
+  'GET /api/saidas':                  'estoque.saidas',
+  // Relatórios
+  'POST /api/estoque/relatorio':      'estoque.relatorio',
+  'GET /api/estoque/relatorios':      'estoque.relatorio',
+  'GET /api/estoque/relatorio/html':  'estoque.relatorio',
+  'POST /api/estoque/relatorio/pdf':  'estoque.relatorio',
+  // Forecast / Análise
+  'GET /api/estoque/previsao':        'dashboard_analise_estoque',
+  'POST /api/estoque/previsao':       'dashboard_analise_estoque',
+  // Configurações (admin)
+  // As RPCs admin são chamadas via Supabase diretamente, não pela API
+}
+
+const EXEMPT_ROUTES = new Set([
+  'auth.login', 'auth.recover', 'health.check',
+])
+
+// Resolve rota normalizada a partir do path e method
+const resolveRouteKey = (method, path) => {
+  // Normaliza paths com ID: /api/pessoas/xxx → /api/pessoas
+  const basePath = path
+    .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '')
+    .replace(/\/history\/.*$/, '')
+    .replace(/\/register-exam\/.*$/, '/register-exam')
+    .replace(/\/price-history\/.*$/, '')
+    .replace(/\/+$/, '')
+
+  return `${method} ${basePath}`
+}
+
+// Cache simples de permissões por user_id (TTL 60s)
+const cache = new Map()
+const CACHE_TTL_MS = 60_000
+
+const getUserPermissions = async (userId, tenantId) => {
+  const cacheKey = `${userId}|${tenantId}`
+  const cached = cache.get(cacheKey)
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.permissions
+  }
+
+  // Busca role + overrides do usuário
+  const { data, error } = await supabaseAdmin.rpc(
+    'get_user_effective_permissions',
+    { p_user_id: userId, p_owner_id: tenantId }
+  )
+
+  if (error) {
+    console.warn('[PERM_GUARD] Falha ao buscar permissões:', error.message)
+    // Falha silenciosa → nega acesso (fail-closed)
+    return []
+  }
+
+  const permissions = Array.isArray(data) ? data : (data?.permissions || [])
+  cache.set(cacheKey, { permissions, ts: Date.now() })
+  return permissions
+}
+
+export async function permissionGuard(ctx) {
+  if (!ctx?.raw?.req) return undefined
+  if (EXEMPT_ROUTES.has(ctx.route)) return undefined
+  if (ctx.isCron || ctx.raw.req?.isCron) return undefined
+  if (!ctx.user) return undefined
+
+  const method = ctx.method || (ctx.raw.req.method || '').toUpperCase()
+  const path = (ctx.raw.req.url || '').split('?')[0]
+  const routeKey = resolveRouteKey(method, path)
+
+  const requiredPerm = ROUTE_PERMISSIONS[routeKey]
+  if (!requiredPerm) {
+    // Rota não mapeada → acesso livre para autenticados
+    return undefined
+  }
+
+  // Master tem acesso total
+  const userMeta = ctx.user?.app_metadata || ctx.user?.user_metadata || {}
+  if (userMeta.credential === 'master' || userMeta.role === 'master') {
+    return undefined
+  }
+
+  // Admin tem acesso total (comportamento atual do front)
+  if (userMeta.credential === 'admin' || userMeta.role === 'admin') {
+    return undefined
+  }
+
+  const permissions = await getUserPermissions(ctx.user.id, ctx.tenantId)
+  if (permissions.includes(requiredPerm)) {
+    return undefined
+  }
+
+  throw createHttpError(403, 'Sem permissao para esta operacao.', {
+    code: 'RLS_DENIED',
+  })
+}
+```
+
+#### [NEW] RPC `get_user_effective_permissions` — migration SQL
+
+```sql
+-- Migration: get_user_effective_permissions
+-- Retorna lista flat de permission keys efetivas para o usuário
+
+CREATE OR REPLACE FUNCTION public.get_user_effective_permissions(
+  p_user_id uuid,
+  p_owner_id uuid
+)
+RETURNS text[]
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_credential text;
+  v_role_permissions text[];
+  v_override_permissions text[];
+  v_result text[];
+BEGIN
+  -- Busca credential do user_roles
+  SELECT credential INTO v_credential
+    FROM public.user_roles
+   WHERE auth_user_id = p_user_id
+     AND scope_parent_user_id = p_owner_id
+   LIMIT 1;
+
+  -- Master/admin: retorna vazio (caller trata como "tudo liberado")
+  IF v_credential IN ('master', 'admin') THEN
+    RETURN ARRAY[]::text[];
+  END IF;
+
+  -- Busca permissions da role
+  SELECT COALESCE(permissions, ARRAY[]::text[]) INTO v_role_permissions
+    FROM public.roles
+   WHERE LOWER(nome) = LOWER(COALESCE(v_credential, 'visitante'))
+   LIMIT 1;
+
+  -- Busca overrides do usuário
+  SELECT COALESCE(array_agg(permission_key), ARRAY[]::text[])
+    INTO v_override_permissions
+    FROM public.user_permission_overrides
+   WHERE auth_user_id = p_user_id
+     AND scope_parent_user_id = p_owner_id
+     AND granted = true;
+
+  -- Merge: role + overrides
+  v_result := v_role_permissions || v_override_permissions;
+
+  RETURN v_result;
+END;
+$$;
+```
+
+> [!WARNING]
+> Esta RPC depende da estrutura exata das tabelas `user_roles`, `roles` e `user_permission_overrides`. Preciso confirmar os nomes das colunas atuais antes de criar a migration final. Se as tabelas usarem nomes diferentes, ajusto.
+
+#### [MODIFY] [withAuth.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/withAuth.js)
+
+Adicionar `permissionGuard` no pipeline, após `tenantGuard`:
+
+```diff
+ import { rateLimitAuth, rateLimitApi } from './middleware/rateLimit.js'
+ import { idempotency } from './middleware/idempotency.js'
++import { permissionGuard } from './middleware/permissionGuard.js'
+ import { errorHandler } from './middleware/errorHandler.js'
+
+ export function withAuth(handler) {
+   const pipeline = compose(
+     requestId,
+     cors,
+     auth,
+     rateLimitAuth,
+     tenantResolve,
+     tenantGuard,
++    permissionGuard,
+     rateLimitApi,
+     idempotency,
+     handlerAdapter(handler),
+     errorHandler
+   )
+```
+
+---
+
+### 3. 🟡 Idempotência para ASO
+
+**Problema**: Rotas `create.aso` e `register.aso-exam` não estão na lista de `IDEMPOTENCY_ROUTES` nem no mapeamento de `route.js`.
+
+#### [MODIFY] [route.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/route.js)
+
+```diff
+ const ROUTES = [
+   { method: 'POST', path: '/api/auth/login', route: 'auth.login' },
+   { method: 'POST', path: '/api/auth/recover', route: 'auth.recover' },
+   { method: 'POST', path: '/api/pessoas', route: 'create.pessoa' },
+   { method: 'POST', path: '/api/materiais', route: 'create.material' },
+   { method: 'POST', path: '/api/acidentes', route: 'create.acidente' },
+   { method: 'POST', path: '/api/entradas', route: 'create.entrada' },
+   { method: 'POST', path: '/api/saidas', route: 'create.saida' },
++  { method: 'POST', path: '/api/aso', route: 'create.aso' },
+   { method: 'GET', path: '/api/health', route: 'health.check' },
+ ]
+```
+
+> [!NOTE]
+> `register-exam` é uma rota com path dinâmico (`/api/aso/register-exam/:id`), o que torna o match exato no `route.js` mais complexo. Opção: registrar como `register.aso-exam` com match por `startsWith`.
+
+#### [MODIFY] [idempotency.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/idempotency.js)
+
+```diff
+ const IDEMPOTENCY_ROUTES = new Set([
+   'create.pessoa',
+   'create.material',
+   'create.acidente',
+   'create.entrada',
+   'create.saida',
++  'create.aso',
+ ])
+```
+
+#### [MODIFY] [rateLimit.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/rateLimit.js)
+
+```diff
+ const CREATE_ROUTES = new Set([
+   'create.pessoa',
+   'create.material',
+   'create.acidente',
+   'create.entrada',
+   'create.saida',
++  'create.aso',
+ ])
+```
+
+---
+
+### 4. 🟡 Rate Limit Expandido
+
+**Depende da resposta do usuário** sobre Opção A vs B.
+
+Se Opção A (recomendado), adicionarei rotas de leitura sensíveis:
+
+#### [MODIFY] [rateLimit.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/middleware/rateLimit.js)
+
+```diff
++const READ_SENSITIVE_ROUTES = new Set([
++  'GET /api/estoque/relatorio/html',
++  'POST /api/estoque/relatorio',
++  'POST /api/estoque/relatorio/pdf',
++  'GET /api/estoque/relatorios',
++])
+```
+
+E uma terceira função `rateLimitRead` no pipeline. A implementação exata depende da decisão.
+
+---
+
+### 5. 🟡 Audit Log (tabela + registro de ações)
+
+#### [NEW] Migration SQL — `create_audit_log.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS public.audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_owner_id uuid NOT NULL REFERENCES public.app_users(id),
+  user_id uuid,
+  action text NOT NULL,          -- 'create', 'update', 'delete', 'cancel'
+  entity text NOT NULL,          -- 'pessoa', 'material', 'entrada', 'saida', 'acidente', 'aso'
+  entity_id uuid,
+  ip_hash text,
+  ua_hash text,
+  session_id text,
+  request_id text,
+  payload_hash text,             -- SHA256 do body (sem dados sensíveis)
+  metadata jsonb,                -- dados adicionais (campos alterados, etc.)
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_audit_log_owner ON public.audit_log(account_owner_id);
+CREATE INDEX idx_audit_log_user ON public.audit_log(user_id);
+CREATE INDEX idx_audit_log_entity ON public.audit_log(entity, entity_id);
+CREATE INDEX idx_audit_log_created ON public.audit_log(created_at DESC);
+
+ALTER TABLE public.audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Apenas leitura para master
+CREATE POLICY "audit_log_select_master" ON public.audit_log
+  FOR SELECT USING (public.current_actor_is_master());
+
+-- Insert via API (security definer nos RPCs ou via supabaseAdmin)
+CREATE POLICY "audit_log_insert_service" ON public.audit_log
+  FOR INSERT WITH CHECK (true);
+```
+
+#### [NEW] [auditLog.js](file:///d:/Fabricio/Projetos%20SaaS/API-Estoque/api/_shared/auditLog.js)
+
+Módulo utilitário para registrar ações, chamado dentro das operations após cada create/update:
+
+```javascript
+import { createHash } from 'node:crypto'
+import { supabaseAdmin } from './supabaseClient.js'
+
+const hashPayload = (body) => {
+  if (!body) return null
+  return createHash('sha256')
+    .update(JSON.stringify(body))
+    .digest('hex')
+}
+
+export async function logAudit({
+  ownerId, userId, action, entity, entityId,
+  ipHash, uaHash, sessionId, requestId,
+  payload, metadata,
+}) {
+  try {
+    await supabaseAdmin.from('audit_log').insert({
+      account_owner_id: ownerId,
+      user_id: userId,
+      action,
+      entity,
+      entity_id: entityId,
+      ip_hash: ipHash || null,
+      ua_hash: uaHash || null,
+      session_id: sessionId || null,
+      request_id: requestId || null,
+      payload_hash: hashPayload(payload),
+      metadata: metadata || null,
+    })
+  } catch (err) {
+    console.warn('[AUDIT] Falha ao registrar auditoria:', err?.message)
+  }
+}
+```
+
+> [!NOTE]
+> O `logAudit` é fire-and-forget (não bloqueia a response). Integração com `operations.js` será feita passando `ctx` para as operations (refactor incremental).
+
+---
+
+## Resumo de arquivos
+
+| Ação | Arquivo | Componente |
+|---|---|---|
+| MODIFY | `api/_shared/middleware/cors.js` | CORS whitelist |
+| NEW | `api/_shared/middleware/permissionGuard.js` | Autorização por permissão |
+| NEW | `supabase/migrations/YYYYMMDD_get_user_effective_permissions.sql` | RPC de permissões |
+| MODIFY | `api/_shared/withAuth.js` | Pipeline (adicionar permissionGuard) |
+| MODIFY | `api/_shared/middleware/route.js` | Adicionar rota ASO |
+| MODIFY | `api/_shared/middleware/idempotency.js` | Adicionar rota ASO |
+| MODIFY | `api/_shared/middleware/rateLimit.js` | Adicionar rota ASO + expandir |
+| NEW | `supabase/migrations/YYYYMMDD_create_audit_log.sql` | Tabela de auditoria |
+| NEW | `api/_shared/auditLog.js` | Módulo de auditoria |
+| CONFIG | `.env.vercel` / Vercel Dashboard | `CORS_ALLOWED_ORIGINS` |
+
+---
+
+## Verification Plan
+
+### Automated Tests
+1. **CORS**: Requisição com `Origin: https://dominio-malicioso.com` → resposta SEM header `Access-Control-Allow-Origin`
+2. **Permission Guard**: Requisição autenticada com usuário sem permissão `estoque.entradas` para `POST /api/entradas` → 403
+3. **Idempotência ASO**: Duas requisições `POST /api/aso` com mesmo `Idempotency-Key` → segunda retorna replay
+4. **Rate limit ASO**: Sequência rápida de `POST /api/aso` → 429 após exceder limite
+
+### Manual Verification
+1. Confirmar que deploy Vercel adiciona `CORS_ALLOWED_ORIGINS`
+2. Testar com usuário `operador` sem permissão de Pessoas → 403 ao tentar `POST /api/pessoas`
+3. Testar com `master` → acesso total mantido
+4. Verificar tabela `audit_log` no Supabase após operações
+
+---
+
+## Open Questions
+
+> [!IMPORTANT]
+> 1. **Quais domínios de produção/staging** devem ir na whitelist CORS?
+> 2. **Rate limit para leitura**: Opção A (só rotas sensíveis) ou B (todas)?
+> 3. **Confirma criação da migration `audit_log`** no Supabase?
+> 4. **Tabelas `user_roles`, `roles` e `user_permission_overrides`**: preciso confirmar os nomes exatos das colunas para a RPC `get_user_effective_permissions`. Posso verificar na pasta `supabasebackup`?
+> 5. **`register-exam`** no ASO: vale fazer match por `startsWith` no `route.js` para cobrir idempotência nessa rota também, ou é suficiente apenas o `create.aso`?


### PR DESCRIPTION
O que foi feito:

- Adiciona plano de correcao de vulnerabilidades de seguranca com prioridades, propostas, pontos pendentes e plano de verificacao.

- Adiciona documentos de referencia sobre arquitetura limpa, autenticacao, nomenclatura, sessoes, Supabase RLS e Realtime.

- Atualiza TASKS.md com o estado atual da documentacao criada e pendencias de decisao antes das correcoes de seguranca.

Arquivos tocados:

- TASKS.md

- docs/Plano de Correção — Vulnerabilidades de Segurança.txt

- docs/Estruturas/*.txt

Mapeamento por modulo/tela:

- Documentacao de seguranca: registra riscos priorizados, propostas para CORS, permission guard, idempotencia, rate limit e audit log.

- Documentacao de arquitetura: consolida referencias para estrutura de software, autenticacao, sessoes, RLS e realtime.

- Gestao de tarefas: reflete itens concluidos e pendentes relacionados ao plano de seguranca.

Como validar:

- Revisar os documentos em docs/ e conferir se as decisoes pendentes do plano correspondem ao estado atual do projeto.

- Rodar git show --stat HEAD para confirmar os arquivos incluidos no commit.

Impacto multi-tenant:

- Nao altera codigo nem schema; o plano documenta validacoes futuras de RLS, account_owner_id, permission guard e audit log.

Docs atualizadas:

- docs/Plano de Correção — Vulnerabilidades de Segurança.txt criado.

- docs/Estruturas/*.txt criados.

- TASKS.md atualizado.