### PR TITLE
fix(auth): corrigir recuperacao de senha para dependentes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,6 +39,8 @@
 - Aba `Compra` da Analise de Estoque passou a reaproveitar o resumo do `estoqueBase` para nao exibir UUID bruto nas listas quando o RPC retorna apenas `material_id`.
 - Documentacao de referencia arquitetural foi adicionada em `docs/Estruturas`, cobrindo arquitetura limpa, autenticacao, nomenclatura, RLS, Realtime e comparativo de sessoes.
 - Plano de correcao de vulnerabilidades de seguranca foi documentado em `docs/Plano de Correção — Vulnerabilidades de Segurança.txt`.
+- Recuperacao de senha de dependentes foi alinhada ao login remoto: `auth-recover` passa a buscar `app_users_dependentes.username` quando nao encontrar titular em `app_users.login_name`.
+- Login publico corrigido para usar o email resolvido (`authEmail`) e bloquear owner/titular inativo antes de autenticar.
 
 ## Pendente
 - Confirmar dominios de producao/staging para configurar whitelist CORS via `CORS_ALLOWED_ORIGINS`.
@@ -56,6 +58,7 @@
   - `supabase/migrations/20260418_03_aso_rpc_update_full.sql`
   - `supabase/migrations/20260418_04_aso_rpc_register_exam_next.sql`
 - Revisar a regra de `PermissionsContext` para role `admin`: hoje ela libera todas as rotas, entao os toggles de pagina em `Credenciais e Permissoes` nao restringem navegacao para esse perfil.
+- Publicar/deploy das Edge Functions `auth-login` e `auth-recover` no projeto Supabase.
 - Publicar/deploy das Edge Functions `aso-template` e `aso-import` no projeto Supabase.
 - Validar no banco o comportamento de `proximo_vencimento`:
   - admissional e periodico somam 1 ano a partir de `data_exame`
@@ -88,3 +91,4 @@
 - Forecast 2026-04-23: a separacao em abas no front e apenas organizacional; a regra do RPC rolling e a persistencia dos snapshots continuam iguais no backend.
 - Forecast 2026-04-23: a persistencia do snapshot agora e versionada por `inventory_forecast_id`, mas o rolling aberto continua atualizando o mesmo `inventory_forecast` enquanto `qtd_meses_base < 12`.
 - Forecast 2026-04-23: a auditoria do snapshot mede qualidade do forecast em meses ja realizados; o diagnostico estatistico continua sendo uma leitura complementar da distribuicao historica mensal.
+- Auth 2026-05-09: admins recebiam email de recuperacao porque eram resolvidos em `app_users`; dependentes podiam receber sucesso sem envio quando estavam apenas em `app_users_dependentes`, pois `auth-recover` nao tinha o fallback existente no login.

--- a/api/_shared/authPublic.js
+++ b/api/_shared/authPublic.js
@@ -17,6 +17,46 @@ const resolveRedirectTo = () => {
   return trimmed ? trimmed : null
 }
 
+async function resolveAuthIdentity(loginName) {
+  const { data: ownerRow, error: ownerError } = await supabaseAdmin
+    .from('app_users')
+    .select('id, email, ativo')
+    .eq('login_name', loginName)
+    .maybeSingle()
+
+  if (ownerError) {
+    throw createHttpError(500, 'Falha ao consultar login.', { code: 'UPSTREAM_ERROR' })
+  }
+
+  if (ownerRow) {
+    return {
+      email: String(ownerRow.email ?? '').trim(),
+      active: ownerRow.ativo !== false,
+      ownerActive: ownerRow.ativo !== false,
+    }
+  }
+
+  const { data: dependentRow, error: dependentError } = await supabaseAdmin
+    .from('app_users_dependentes')
+    .select('id, email, ativo, owner:app_users!app_users_dependentes_owner_app_user_id_fkey (id, ativo)')
+    .eq('username', loginName)
+    .maybeSingle()
+
+  if (dependentError) {
+    throw createHttpError(500, 'Falha ao consultar login.', { code: 'UPSTREAM_ERROR' })
+  }
+
+  if (!dependentRow) {
+    return null
+  }
+
+  return {
+    email: String(dependentRow.email ?? '').trim(),
+    active: dependentRow.ativo !== false,
+    ownerActive: dependentRow.owner?.ativo !== false,
+  }
+}
+
 export async function loginWithLoginName(payload = {}) {
   const loginName = normalizeLoginName(payload.loginName ?? payload.login_name ?? payload.username)
   const password = payload.password ?? ''
@@ -25,26 +65,18 @@ export async function loginWithLoginName(payload = {}) {
     throw createHttpError(400, 'Informe login e senha.', { code: 'VALIDATION_ERROR' })
   }
 
-  const { data: userRow, error } = await supabaseAdmin
-    .from('app_users')
-    .select('id, email, ativo')
-    .eq('login_name', loginName)
-    .maybeSingle()
+  const authIdentity = await resolveAuthIdentity(loginName)
 
-  if (error) {
-    throw createHttpError(500, 'Falha ao consultar login.', { code: 'UPSTREAM_ERROR' })
-  }
-
-  if (!userRow?.email) {
+  if (!authIdentity?.email) {
     throw createHttpError(401, 'Login ou senha invalidos.', { code: 'AUTH_INVALID' })
   }
 
-  if (userRow.ativo === false) {
+  if (authIdentity.active === false || authIdentity.ownerActive === false) {
     throw createHttpError(403, 'Usuario inativo. Procure um administrador.', { code: 'AUTH_INACTIVE' })
   }
 
   const { data, error: signInError } = await supabaseAdmin.auth.signInWithPassword({
-    email: userRow.email,
+    email: authIdentity.email,
     password,
   })
 
@@ -71,21 +103,16 @@ export async function recoverWithLoginName(payload = {}) {
     throw createHttpError(400, 'Informe seu login para recuperar a senha.', { code: 'VALIDATION_ERROR' })
   }
 
-  const { data: userRow, error } = await supabaseAdmin
-    .from('app_users')
-    .select('email')
-    .eq('login_name', loginName)
-    .maybeSingle()
+  const authIdentity = await resolveAuthIdentity(loginName)
 
-  if (error) {
-    throw createHttpError(500, 'Falha ao consultar login.', { code: 'UPSTREAM_ERROR' })
-  }
-
-  const email = String(userRow?.email ?? '').trim()
-  if (userRow && !email) {
+  const email = String(authIdentity?.email ?? '').trim()
+  if (authIdentity && !email) {
     throw createHttpError(422, 'Login sem email cadastrado. Procure um administrador.', {
       code: 'MISSING_EMAIL',
     })
+  }
+  if (authIdentity && (authIdentity.active === false || authIdentity.ownerActive === false)) {
+    throw createHttpError(403, 'Usuario inativo. Procure um administrador.', { code: 'AUTH_INACTIVE' })
   }
   if (!email) {
     return { ok: true }

--- a/docs/Login.txt
+++ b/docs/Login.txt
@@ -168,6 +168,19 @@ Atualizacao 2026-03 (Debug auth-recover)
 - Arquivos alterados/criados:
 - `supabase/functions/auth-recover/index.ts`
 
+Atualizacao 2026-05 (Recuperacao dependentes)
+
+- Recuperacao de senha agora usa o mesmo criterio do login remoto: tenta titular em `app_users.login_name` e, se nao encontrar, tenta dependente em `app_users_dependentes.username`.
+- Dependentes e titulares/owners inativos sao bloqueados com `AUTH_INACTIVE` antes de chamar o envio de reset.
+- Login publico foi corrigido para autenticar com o email resolvido (`authEmail`) e nao com variavel inexistente.
+- Arquivos alterados/criados:
+- `supabase/functions/auth-recover/index.ts`
+- `supabase/functions/auth-login/index.ts`
+- `api/_shared/authPublic.js`
+- Antes/Depois:
+- Antes: um dependente existente apenas em `app_users_dependentes` recebia resposta generica de sucesso no "Esqueceu a senha?", mas nenhum email era enviado.
+- Depois: o dependente e resolvido pelo username legado, o email cadastrado e usado no reset e usuarios inativos continuam bloqueados.
+
 Atualizacao 2026-03 (Cache/tenant no login)
 
 - Limpeza de caches antes de setSession e antes de resolver usuario no onAuthStateChange.
@@ -248,7 +261,7 @@ Servicos e integracoes externas
 - authPublic (loginWithLoginName, recoverWithLoginName)
   - Tipo: handlers publicos de auth
   - Caminho: api/_shared/authPublic.js
-  - Responsavel por: resolver login_name para email e autenticar no backend sem expor email.
+  - Responsavel por: resolver titular/dependente para email e autenticar ou enviar recuperacao no backend sem expor email.
 - validateSession / touchSession / revokeSession
   - Tipo: guard de sessao no backend
   - Caminho: api/_shared/sessionActivity.js

--- a/supabase/functions/auth-login/index.ts
+++ b/supabase/functions/auth-login/index.ts
@@ -121,8 +121,14 @@ serve(async (req) => {
     return respond(500, { error: { message: 'Falha ao consultar login.', code: 'UPSTREAM_ERROR' } })
   }
 
-  let authEmail = ownerRow?.email || ''
+  let authEmail = String(ownerRow?.email ?? '').trim()
   let ownerActive = ownerRow?.ativo !== false
+
+  if (ownerRow && ownerActive === false) {
+    return respond(403, {
+      error: { message: 'Usuario inativo. Procure um administrador.', code: 'AUTH_INACTIVE' },
+    })
+  }
 
   if (!authEmail) {
     const { data: dependentRow, error: dependentError } = await supabase
@@ -153,7 +159,7 @@ serve(async (req) => {
   }
 
   const { data, error: signInError } = await supabase.auth.signInWithPassword({
-    email: userRow.email,
+    email: authEmail,
     password,
   })
 

--- a/supabase/functions/auth-recover/index.ts
+++ b/supabase/functions/auth-recover/index.ts
@@ -61,6 +61,54 @@ const supabase = createClient(supabaseUrl, serviceRoleKey, {
   },
 })
 
+const resolveAuthIdentity = async (loginName: string) => {
+  const { data: ownerRow, error: ownerError } = await supabase
+    .from('app_users')
+    .select('id, email, ativo')
+    .eq('login_name', loginName)
+    .maybeSingle()
+
+  if (ownerError) {
+    return { user: null, error: ownerError }
+  }
+
+  if (ownerRow) {
+    return {
+      user: {
+        email: String(ownerRow.email ?? '').trim(),
+        active: ownerRow.ativo !== false,
+        ownerActive: ownerRow.ativo !== false,
+      },
+      error: null,
+    }
+  }
+
+  const { data: dependentRow, error: dependentError } = await supabase
+    .from('app_users_dependentes')
+    .select(
+      `id, email, ativo, owner:app_users!app_users_dependentes_owner_app_user_id_fkey (id, ativo)`
+    )
+    .eq('username', loginName)
+    .maybeSingle()
+
+  if (dependentError) {
+    return { user: null, error: dependentError }
+  }
+
+  if (!dependentRow) {
+    return { user: null, error: null }
+  }
+
+  return {
+    user: {
+      email: String(dependentRow.email ?? '').trim(),
+      active: dependentRow.ativo !== false,
+      ownerActive: dependentRow.owner?.ativo !== false,
+    },
+    error: null,
+  }
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
@@ -114,20 +162,22 @@ serve(async (req) => {
     )
   }
 
-  const { data: userRow, error } = await supabase
-    .from('app_users')
-    .select('email')
-    .eq('login_name', loginName)
-    .maybeSingle()
+  const { user: authIdentity, error } = await resolveAuthIdentity(loginName)
 
   if (error) {
     return respond(500, { error: { message: 'Falha ao consultar login.', code: 'UPSTREAM_ERROR' } })
   }
 
-  const email = String(userRow?.email ?? '').trim()
-  if (userRow && !email) {
+  const email = String(authIdentity?.email ?? '').trim()
+  if (authIdentity && !email) {
     return respond(422, {
       error: { message: 'Login sem email cadastrado. Procure um administrador.', code: 'MISSING_EMAIL' },
+    })
+  }
+
+  if (authIdentity && (authIdentity.active === false || authIdentity.ownerActive === false)) {
+    return respond(403, {
+      error: { message: 'Usuario inativo. Procure um administrador.', code: 'AUTH_INACTIVE' },
     })
   }
 


### PR DESCRIPTION
- O que foi feito:
  - auth-recover agora resolve dependentes em app_users_dependentes quando nao encontra titular em app_users.
  - auth-login usa o email resolvido e bloqueia titular/owner inativo.
  - authPublic reutiliza a mesma regra para login e recuperacao publica.
  - TASKS.md e docs/Login.txt atualizados.

- Arquivos:
  - supabase/functions/auth-recover/index.ts
  - supabase/functions/auth-login/index.ts
  - api/_shared/authPublic.js
  - docs/Login.txt
  - TASKS.md

- Mapeamento:
  - Tela Login: recuperacao por login passa a funcionar para dependentes legados.
  - Edge Functions Auth: resolucao de identidade alinhada entre login e recovery.

- Como validar:
  - npm run build
  - Deploy das Edge Functions auth-login/auth-recover
  - Testar "Esqueceu a senha?" com admin e dependente ativo com email cadastrado.

- Multi-tenant:
  - Sem mudanca de schema/RLS.
  - Dependente continua limitado ao owner; usuario/owner inativo bloqueia recovery.

- Docs:
  - docs/Login.txt atualizado
  - TASKS.md atualizado