### PR TITLE
fix(auth): diagnosticar e corrigir recovery de dependentes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -41,6 +41,7 @@
 - Plano de correcao de vulnerabilidades de seguranca foi documentado em `docs/Plano de Correção — Vulnerabilidades de Segurança.txt`.
 - Recuperacao de senha de dependentes foi alinhada ao login remoto: `auth-recover` passa a buscar `app_users_dependentes.username` quando nao encontrar titular em `app_users.login_name`.
 - Login publico corrigido para usar o email resolvido (`authEmail`) e bloquear owner/titular inativo antes de autenticar.
+- Diagnostico de `auth-recover` foi reforcado com logs por etapa e consulta explicita do owner do dependente, sem relacionamento embutido.
 
 ## Pendente
 - Confirmar dominios de producao/staging para configurar whitelist CORS via `CORS_ALLOWED_ORIGINS`.
@@ -92,3 +93,4 @@
 - Forecast 2026-04-23: a persistencia do snapshot agora e versionada por `inventory_forecast_id`, mas o rolling aberto continua atualizando o mesmo `inventory_forecast` enquanto `qtd_meses_base < 12`.
 - Forecast 2026-04-23: a auditoria do snapshot mede qualidade do forecast em meses ja realizados; o diagnostico estatistico continua sendo uma leitura complementar da distribuicao historica mensal.
 - Auth 2026-05-09: admins recebiam email de recuperacao porque eram resolvidos em `app_users`; dependentes podiam receber sucesso sem envio quando estavam apenas em `app_users_dependentes`, pois `auth-recover` nao tinha o fallback existente no login.
+- Auth 2026-05-09: se o request log mostrar 500 em `auth-recover`, verificar Function Logs da mesma execucao; o log agora informa `stage` para separar falha de rate limit, lookup do dependente/owner ou envio pelo Supabase Auth.

--- a/api/_shared/authPublic.js
+++ b/api/_shared/authPublic.js
@@ -38,7 +38,7 @@ async function resolveAuthIdentity(loginName) {
 
   const { data: dependentRow, error: dependentError } = await supabaseAdmin
     .from('app_users_dependentes')
-    .select('id, email, ativo, owner:app_users!app_users_dependentes_owner_app_user_id_fkey (id, ativo)')
+    .select('id, email, ativo, owner_app_user_id')
     .eq('username', loginName)
     .maybeSingle()
 
@@ -50,10 +50,20 @@ async function resolveAuthIdentity(loginName) {
     return null
   }
 
+  const { data: dependentOwner, error: dependentOwnerError } = await supabaseAdmin
+    .from('app_users')
+    .select('id, ativo')
+    .eq('id', dependentRow.owner_app_user_id)
+    .maybeSingle()
+
+  if (dependentOwnerError) {
+    throw createHttpError(500, 'Falha ao consultar login.', { code: 'UPSTREAM_ERROR' })
+  }
+
   return {
     email: String(dependentRow.email ?? '').trim(),
     active: dependentRow.ativo !== false,
-    ownerActive: dependentRow.owner?.ativo !== false,
+    ownerActive: Boolean(dependentOwner) && dependentOwner.ativo !== false,
   }
 }
 

--- a/docs/Login.txt
+++ b/docs/Login.txt
@@ -173,6 +173,8 @@ Atualizacao 2026-05 (Recuperacao dependentes)
 - Recuperacao de senha agora usa o mesmo criterio do login remoto: tenta titular em `app_users.login_name` e, se nao encontrar, tenta dependente em `app_users_dependentes.username`.
 - Dependentes e titulares/owners inativos sao bloqueados com `AUTH_INACTIVE` antes de chamar o envio de reset.
 - Login publico foi corrigido para autenticar com o email resolvido (`authEmail`) e nao com variavel inexistente.
+- Consultas de dependente deixaram de usar relacionamento embutido com owner; o owner e consultado explicitamente para evitar falha de relacionamento ambíguo no PostgREST.
+- Logs de `auth-recover` agora registram a etapa da falha (`rate_limit`, `dependent_lookup`, `dependent_owner_lookup`, `reset_password_for_email`).
 - Arquivos alterados/criados:
 - `supabase/functions/auth-recover/index.ts`
 - `supabase/functions/auth-login/index.ts`

--- a/supabase/functions/auth-login/index.ts
+++ b/supabase/functions/auth-login/index.ts
@@ -133,9 +133,7 @@ serve(async (req) => {
   if (!authEmail) {
     const { data: dependentRow, error: dependentError } = await supabase
       .from('app_users_dependentes')
-      .select(
-        `id, email, ativo, owner:app_users!app_users_dependentes_owner_app_user_id_fkey (id, ativo)`
-      )
+      .select('id, email, ativo, owner_app_user_id')
       .eq('username', loginName)
       .maybeSingle()
 
@@ -145,7 +143,23 @@ serve(async (req) => {
 
     if (dependentRow?.email) {
       authEmail = String(dependentRow.email).trim()
-      ownerActive = dependentRow?.owner?.ativo !== false
+      const { data: dependentOwner, error: dependentOwnerError } = await supabase
+        .from('app_users')
+        .select('id, ativo')
+        .eq('id', dependentRow.owner_app_user_id)
+        .maybeSingle()
+
+      if (dependentOwnerError) {
+        console.error('auth-login dependent owner lookup failed', {
+          message: dependentOwnerError.message,
+          code: dependentOwnerError.code,
+          details: dependentOwnerError.details,
+          hint: dependentOwnerError.hint,
+        })
+        return respond(500, { error: { message: 'Falha ao consultar login.', code: 'UPSTREAM_ERROR' } })
+      }
+
+      ownerActive = Boolean(dependentOwner) && dependentOwner.ativo !== false
       if (dependentRow.ativo === false || ownerActive === false) {
         return respond(403, {
           error: { message: 'Usuario inativo. Procure um administrador.', code: 'AUTH_INACTIVE' },

--- a/supabase/functions/auth-recover/index.ts
+++ b/supabase/functions/auth-recover/index.ts
@@ -61,6 +61,18 @@ const supabase = createClient(supabaseUrl, serviceRoleKey, {
   },
 })
 
+const logRecoverError = (stage: string, error: unknown) => {
+  const err = error as { message?: string; code?: string; status?: number; details?: string; hint?: string }
+  console.error('auth-recover failed', {
+    stage,
+    message: err?.message || String(error),
+    code: err?.code,
+    status: err?.status,
+    details: err?.details,
+    hint: err?.hint,
+  })
+}
+
 const resolveAuthIdentity = async (loginName: string) => {
   const { data: ownerRow, error: ownerError } = await supabase
     .from('app_users')
@@ -69,7 +81,7 @@ const resolveAuthIdentity = async (loginName: string) => {
     .maybeSingle()
 
   if (ownerError) {
-    return { user: null, error: ownerError }
+    return { user: null, error: ownerError, stage: 'owner_lookup' }
   }
 
   if (ownerRow) {
@@ -80,32 +92,42 @@ const resolveAuthIdentity = async (loginName: string) => {
         ownerActive: ownerRow.ativo !== false,
       },
       error: null,
+      stage: null,
     }
   }
 
   const { data: dependentRow, error: dependentError } = await supabase
     .from('app_users_dependentes')
-    .select(
-      `id, email, ativo, owner:app_users!app_users_dependentes_owner_app_user_id_fkey (id, ativo)`
-    )
+    .select('id, email, ativo, owner_app_user_id')
     .eq('username', loginName)
     .maybeSingle()
 
   if (dependentError) {
-    return { user: null, error: dependentError }
+    return { user: null, error: dependentError, stage: 'dependent_lookup' }
   }
 
   if (!dependentRow) {
-    return { user: null, error: null }
+    return { user: null, error: null, stage: null }
+  }
+
+  const { data: dependentOwner, error: dependentOwnerError } = await supabase
+    .from('app_users')
+    .select('id, ativo')
+    .eq('id', dependentRow.owner_app_user_id)
+    .maybeSingle()
+
+  if (dependentOwnerError) {
+    return { user: null, error: dependentOwnerError, stage: 'dependent_owner_lookup' }
   }
 
   return {
     user: {
       email: String(dependentRow.email ?? '').trim(),
       active: dependentRow.ativo !== false,
-      ownerActive: dependentRow.owner?.ativo !== false,
+      ownerActive: Boolean(dependentOwner) && dependentOwner.ativo !== false,
     },
     error: null,
+    stage: null,
   }
 }
 
@@ -141,6 +163,7 @@ serve(async (req) => {
   )
 
   if (rateError) {
+    logRecoverError('rate_limit', rateError)
     return respond(500, {
       error: { message: 'Falha ao validar limite de requisicoes.', code: 'UPSTREAM_ERROR' },
     })
@@ -162,9 +185,10 @@ serve(async (req) => {
     )
   }
 
-  const { user: authIdentity, error } = await resolveAuthIdentity(loginName)
+  const { user: authIdentity, error, stage } = await resolveAuthIdentity(loginName)
 
   if (error) {
+    logRecoverError(stage || 'identity_lookup', error)
     return respond(500, { error: { message: 'Falha ao consultar login.', code: 'UPSTREAM_ERROR' } })
   }
 
@@ -188,11 +212,7 @@ serve(async (req) => {
   const options = redirectTo ? { redirectTo } : undefined
   const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, options)
   if (resetError) {
-    console.error('auth-recover resetPasswordForEmail failed', {
-      message: resetError.message,
-      status: resetError.status,
-      code: resetError.code,
-    })
+    logRecoverError('reset_password_for_email', resetError)
     return respond(500, {
       error: {
         message: 'Falha ao enviar email de recuperacao.',


### PR DESCRIPTION
- O que foi feito:
  - auth-recover passou a resolver dependentes sem relacionamento embutido com owner.
  - auth-recover passou a registrar stage da falha nos logs.
  - auth-login e authPublic foram alinhados com a mesma consulta explicita.
  - TASKS.md e docs/Login.txt atualizados.

- Arquivos:
  - supabase/functions/auth-recover/index.ts
  - supabase/functions/auth-login/index.ts
  - api/_shared/authPublic.js
  - docs/Login.txt
  - TASKS.md

- Como validar:
  - npm run build
  - Deploy das functions auth-recover/auth-login
  - Testar recuperacao com admin e dependente ativo.

- Multi-tenant:
  - Sem schema novo.
  - Owner do dependente e validado antes do envio.

- Docs:
  - docs/Login.txt atualizado
  - TASKS.md atualizado