### PR TITLE
fix(dashboard-acidentes): corrigir soma de HHT mensal

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -42,6 +42,9 @@
 - Recuperacao de senha de dependentes foi alinhada ao login remoto: `auth-recover` passa a buscar `app_users_dependentes.username` quando nao encontrar titular em `app_users.login_name`.
 - Login publico corrigido para usar o email resolvido (`authEmail`) e bloquear owner/titular inativo antes de autenticar.
 - Diagnostico de `auth-recover` foi reforcado com logs por etapa e consulta explicita do owner do dependente, sem relacionamento embutido.
+- Corrigido o fallback JS do Dashboard de Acidentes para somar HHT mensal ativo por periodo/centro, independente de acidente no mesmo centro/mes.
+- Migration `supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql` criada para recriar `vw_indicadores_acidentes` com HHT mensal agregado por periodo e `account_owner_id`.
+- Documentacao `docs/DashboardAcidentes.txt` atualizada com o diagnostico do HHT 2026 e o comportamento antes/depois.
 
 ## Pendente
 - Confirmar dominios de producao/staging para configurar whitelist CORS via `CORS_ALLOWED_ORIGINS`.
@@ -53,6 +56,7 @@
 - Aplicar a migration `supabase/migrations/20260423_fix_forecast_snapshot_versioning.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260423_add_forecast_audit_and_purchase_rpcs.sql` no projeto Supabase.
 - Aplicar a migration `supabase/migrations/20260423_fix_forecast_audit_purchase_security_definer.sql` no projeto Supabase.
+- Aplicar a migration `supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql` no projeto Supabase para ativar a correcao da view `vw_indicadores_acidentes`.
 - Aplicar no projeto Supabase, nesta ordem:
   - `supabase/migrations/20260418_01_aso_mudanca_funcao_schema.sql`
   - `supabase/migrations/20260418_02_aso_rpc_create_full.sql`
@@ -94,3 +98,4 @@
 - Forecast 2026-04-23: a auditoria do snapshot mede qualidade do forecast em meses ja realizados; o diagnostico estatistico continua sendo uma leitura complementar da distribuicao historica mensal.
 - Auth 2026-05-09: admins recebiam email de recuperacao porque eram resolvidos em `app_users`; dependentes podiam receber sucesso sem envio quando estavam apenas em `app_users_dependentes`, pois `auth-recover` nao tinha o fallback existente no login.
 - Auth 2026-05-09: se o request log mostrar 500 em `auth-recover`, verificar Function Logs da mesma execucao; o log agora informa `stage` para separar falha de rate limit, lookup do dependente/owner ou envio pelo Supabase Auth.
+- Dashboard Acidentes 2026-08-01: para o owner `59191387-669b-4585-8e11-7070d9769d86`, havia 5 HHT ativos em 03/2026 somando 99.120,67 e 24 acidentes ativos em 2026; nenhum grupo `mes + centro_servico_id` dos acidentes tinha HHT correspondente, por isso a regra antiga retornava HHT total 0.

--- a/docs/CarregamentoListas.txt
+++ b/docs/CarregamentoListas.txt
@@ -1,0 +1,144 @@
+Carregamento de Listas nas Telas
+=================================
+
+Visao geral
+-----------
+- Documenta, para as mesmas 7 telas de `docs/ExportacaoExcel.txt` (Acidentes, ASO, Entradas, Saidas, Pessoas, Materiais, Estoque Atual), como a lista principal chega na tela: Pagina -> Context -> Hook/Controller -> Servico (`src/services/*Service.js`) -> `dataClient` (`api.js` remoto ou `localApi.js` local) -> tabela/RPC do Supabase -> estado em memoria -> renderizacao.
+- `src/services/dataClient.js` escolhe `api` = `src/services/api.js` (Supabase) quando `isLocalMode` (`src/config/runtime.js`) e falso, ou `src/services/localApi.js` (in-memory/localStorage) quando `VITE_DATA_MODE=local` em dev. Ver `docs/data-mode-guide.txt` para detalhes do toggle.
+- Duas pecas centrais em `api.js`:
+  - `execute(builder, msg)` (`src/services/api.js:1887`) roda uma unica chamada Supabase e trata erro padrao.
+  - `executePaged(buildQuery, msg, opts)` (`src/services/api.js:1896-1914`) percorre `.range(from, from+pageSize-1)` com `pageSize=1000` e `maxPages=50` ate esgotar os dados — usado apenas por `pessoas.list`/busca. Isso busca **o resultado inteiro do filtro** em blocos de 1000, nao e paginacao de tela.
+- Nenhuma das 7 telas usa `.range()`/`.limit()` do Supabase para limitar a lista exibida ao usuario. A paginacao que o usuario ve (quando existe) e sempre um `slice()` em memoria sobre a lista ja carregada por completo.
+- Multi-tenant: `entradas`, `saidas`, `materiais*`, `pessoas` dependem de RLS via `current_account_owner_id()` (ver `docs/rls-multi-tenant-map.txt`). Pessoas e a unica tela que soma um filtro extra no app (`resolvePessoasOwnerScope`, ver abaixo) alem da RLS.
+
+Resumo comparativo
+------------------
+- Paginacao de tela: Entradas e Saidas usam `TABLE_PAGE_SIZE = 20` (`src/config/pagination.js:1`) via slice em memoria; Pessoas e Materiais nao paginam (renderizam a lista inteira); Estoque pagina Alertas (6) e Itens (10) separadamente, tambem via slice em memoria.
+- Filtragem: Acidentes e Materiais sao 100% client-side (carregam tudo uma vez, filtram em `useMemo`/funcao local); Entradas, Saidas e Estoque sao hibridas (uma parte dos filtros vai para o servidor, mas a lista carregada e refiltrada de novo no cliente); Pessoas e hibrida "invertida": o servidor filtra apenas na recarga forcada, e toda interacao de filtro subsequente reaproveita o cache local sem nova chamada.
+- Cache entre chamadas: so existe em Pessoas (`pessoasOptionsRef`, reaproveita a mesma lista carregada entre varias combinacoes de filtro) e em Estoque (`lastLoadKeyRef`/`lastBaseKeyRef`, cache de deduplicacao — so evita repetir a mesma chamada identica). Acidentes, ASO, Entradas, Saidas e Materiais sempre refazem a chamada ao servidor em "Aplicar"/"Atualizar".
+
+Acidentes
+---------
+- Pagina: `src/pages/Acidentes.jsx`.
+- Hook de dados: `src/hooks/useAcidentes.js` — estado `acidentes`, `isLoading`, `error`.
+  - Carga inicial: `useEffect(() => { reload() }, [reload])` (linhas 22-24) chama `reload()` uma vez ao montar.
+  - `reload()` (linhas 9-20) chama `listAcidentes()` (sem parametros) e substitui `acidentes` por completo.
+- Hook de filtro: `src/hooks/useAcidenteFiltro.js` (`acidentesFiltrados`, linha 38) — filtra em memoria a lista ja carregada; nao ha chamada ao servidor por filtro.
+- Servico: `src/services/acidentesService.js` -> `listAcidentes() => api.acidentes.list()`/`dataClient`.
+- Paginacao: nenhuma — lista completa renderizada.
+- Padrao mais simples das 7 telas: uma unica carga de tudo no mount, filtro e exportacao sempre client-side sobre essa carga.
+
+ASO
+---
+- Pagina: `src/pages/AsoPage.jsx`.
+- Hook: `src/hooks/useAsoController.js` — estados `asos` (lista filtrada exibida) e `allAsos` (lista completa, sem filtro, usada so para checagem de conflitos/duplicidade ao salvar).
+  - Carga inicial: `useEffect(() => { loadDependencies(); refreshAsoData(ASO_FILTER_DEFAULT) }, [...])` (linhas 133-136).
+  - `refreshAsoData(params)` (linhas 126-131) roda `Promise.all([loadAsosData(params), loadAllAsosData()])` — duas chamadas paralelas ao mesmo `listAsos`, uma com filtros e outra sem (`{}`).
+  - `loadAsosData(params)` (linhas 100-115) chama `listAsos(params)` e substitui `asos`.
+  - Filtro "Aplicar" (`handleFilterSubmit`, linhas 229-232) chama `loadAsosData(filters)` diretamente — filtro e sempre resolvido no servidor, sem refiltro em memoria.
+- Servico: `src/services/asoService.js` -> `listAsos(params) => api.aso.list(params)` (delega ao Supabase com os filtros no payload).
+- Auxiliares carregados junto: `listAsoTiposExame()` e `listPessoasReferences()` (`loadDependencies`, linhas 85-98) para popular selects de tipo de exame/centro/setor/cargo.
+- Paginacao: nenhuma.
+- Particularidade: mantem 2 copias da lista (filtrada e completa) para poder validar duplicidade/conflito de exame sem depender do filtro atual da tela.
+
+Entradas
+--------
+- Pagina: `src/pages/EntradasPage.jsx`, dentro de `EntradasProvider` -> `useEntradasContext()` -> `useEntradasController()` (`src/hooks/useEntradasController.js`).
+- Estado: `entradas` (lista bruta) + catalogos auxiliares `materiais`, `centrosCusto`, `statusOptions`.
+- Carga inicial: `useEffect` disparado por `userScopeKey` (troca de usuario/tenant) chama `load(initialEntradaFilters, { resetPage: true, refreshCatalogs: true })`.
+- `load(params, opts)`: roda em paralelo os catalogos (se vazios ou `refreshCatalogs`) e `listEntradas(buildEntradasQuery(params))`; resultado substitui `entradas`.
+- Gatilhos de recarga: botao "Atualizar" (`load(filters, { refreshCatalogs: true })`), "Aplicar filtros" (`load(filters, { resetPage: true })`), "Limpar" (volta aos filtros default + recarrega catalogos), e apos criar/editar/cancelar entrada ou importacao em massa.
+- Paginacao: apenas client-side — `paginatedEntradas` faz `slice` de `filteredEntradas` por `TABLE_PAGE_SIZE` (20); `<TablePagination>` usa `filteredEntradas.length`. Nao ha `.range()` no lado do servidor.
+- Filtragem hibrida (servidor + cliente, ambas aplicadas):
+  - Servidor: `buildEntradasQuery(filters)` (`src/utils/entradasUtils.js`) envia `centroCusto`, `registradoPor`, `status`, `dataInicio`, `dataFim`, `termo` para `carregarEntradas()` (`src/services/api.js`), que monta `.eq/in` no material/centro/status/usuario e range de datas via `buildDateFilters`. O filtro `termo`, porem, e aplicado **depois** da consulta, em JS, contra um mapa de `materiais_view` ja carregado (nao vira `.ilike()` na tabela `entradas`).
+  - Cliente: `filteredEntradas` (`useMemo`) reaplica `centroCusto`/`status`/`registradoPor`/`termo` sobre a lista `entradas` ja em memoria, usando o valor **atual** do formulario de filtro (nao apenas o ultimo aplicado) — por isso digitar no campo de busca refiltra a lista instantaneamente antes mesmo de clicar em "Aplicar filtros", que so dispara uma nova busca no servidor.
+- Servico: `src/services/entradasService.js` -> `listEntradas`, `listMateriais`, `listCentrosEstoque`, `listStatusEntrada`, `searchMateriais`, `createEntrada`/`updateEntrada`/`cancelEntrada`, `getEntradaHistory`.
+- Backend (`api.js`): `entradas.list` -> `carregarEntradas()` -> `supabase.from('entradas').select('*').order('dataEntrada', {ascending:false})` + filtros acima. `materiais.list()` -> `supabase.from('materiais_view').select(...).order('nome')`. `centrosEstoque.list()`/`centrosCusto.list()` -> RPC `rpc_catalog_list` (SECURITY DEFINER). `statusEntrada.list()` -> `supabase.from('status_entrada').select('id, status').eq('ativo', true)`.
+- Auxiliares para exibicao: `materiaisMap` (nome/descricao do material por linha) e `centrosCustoMap`/`resolveCentroCustoLabel` (nome do centro), ambos montados a partir das listas ja carregadas; as opcoes de filtro (`registeredOptions`, `centroCustoFilterOptions`) sao derivadas da propria lista `entradas` carregada, sem busca adicional.
+
+Saidas
+------
+- Pagina: `src/pages/SaidasPage.jsx`, dentro de `SaidasProvider` -> `useSaidasContext()` -> `useSaidasController()` (`src/hooks/useSaidasController.js`).
+- Estado: `saidas` + auxiliares `pessoas`, `materiais`, `centrosEstoqueOptions`, `centrosCustoOptions`, `centrosServicoOptions`, `statusOptions`.
+- Carga inicial: `useEffect` disparado por `userScopeKey` chama `load(initialSaidaFilters, { resetPage: true })`.
+- `load(params, opts)`: roda em paralelo `listPessoas()`, `listMateriais()`, `listSaidas(buildSaidasQuery(params))` e catalogos de centro (se ainda nao carregados); depois complementa pessoas referenciadas nas saidas mas fora do filtro "ativo" padrao via `listPessoasByIds` (para nao perder o nome de pessoas inativas que ja tiveram saida).
+- Gatilhos de recarga: "Atualizar", "Aplicar filtros", "Limpar", apos criar/editar/cancelar saida e apos confirmar troca.
+- Paginacao: client-side, mesmo padrao de Entradas — `paginatedSaidas` faz `slice` de `saidasFiltradas` por `TABLE_PAGE_SIZE` (20).
+- Filtragem hibrida (servidor + cliente):
+  - Servidor: `buildSaidasQuery` envia `centroCusto`, `centroServico`, `registradoPor`, `status`, `dataInicio`, `dataFim`, `termo` para `carregarSaidas()`, que filtra `materialId`, `pessoaId`, `status`, `usuarioResponsavel`, `centro_estoque`, `centro_custo`, `centro_servico` e range de datas; `termo` tambem e resolvido em JS apos a busca (contra `pessoas`/`materiais_view` ja carregados).
+  - **Somente client-side, sem equivalente no servidor**: os filtros `trocaOnly` (apenas saidas com troca) e `trocaPrazo` (prazo da troca) existem so no estado local e sao aplicados no `useMemo` `saidasFiltradas`, junto com uma reaplicacao de `status`/`registradoPor`/`termo` sobre o valor atual do formulario (mesmo comportamento de "preview instantaneo" de Entradas).
+- Servico: `src/services/saidasService.js` -> `listSaidas`, `listPessoas` (`api.pessoas.list({status:'ativo'})`), `listPessoasByIds`, `listMateriais` (prioriza `api.entradas.materialOptions()`/`entradas_material_view`, cai para `api.materiais.list()`), `getMaterialEstoque`, `searchMateriais`/`searchPessoas`, `listCentrosCusto`/`listCentrosServico`/`listCentrosEstoque`.
+- Backend: `saidas.list` -> `carregarSaidas()` -> `supabase.from('saidas').select('*, status_rel:status_saida ( id, status )').order('dataEntrega', {ascending:false})`.
+- Auxiliares: `pessoasMap`/`materiaisMap` (nome, matricula, resumo do material por linha, tambem usados no filtro de `termo`); opcoes de filtro de centro/registrador/status sao derivadas da propria lista `saidas` ja carregada.
+
+Pessoas
+-------
+- Pagina: `src/pages/Pessoas.jsx`, dentro de `PessoasProvider` -> `usePessoasContext()` -> `usePessoasController()` (`src/hooks/usePessoasController.js`).
+- Estado: `pessoas` (lista final, filtrada, exibida) e `pessoasOptions`/`pessoasOptionsRef` (cache da ultima carga completa do servidor).
+- Carga inicial: `useEffect` por `userScopeKey`/id do usuario limpa o cache e chama `loadPessoas(PESSOAS_FILTER_DEFAULT, true)` (forca busca no servidor); outro `useEffect` busca `getPessoasResumo()` uma unica vez.
+- `loadPessoas(params, refreshOptions)` tem um **branch de cache** central (linhas 114-165 de `usePessoasController.js`):
+  - Se `refreshOptions` for falso **e** ja existir cache (`pessoasOptionsRef.current` nao vazio), a funcao **nao chama o servidor**: reenriquece os itens do cache com os mapas de referencia atuais (centro/setor/cargo/tipo de execucao) e aplica `filterPessoas(enrichedPessoas, params)` so em memoria, terminando com `return` antes de qualquer rede.
+  - Somente quando `refreshOptions === true` (ou cache vazio) o codigo chama `listPessoas(params)` de fato, atualiza `pessoasOptionsRef`/`pessoasOptions` e depois reaplica `filterPessoas` do mesmo jeito.
+- Gatilhos de recarga:
+  - "Atualizar" -> `loadPessoas(filters, true)` — forca ida ao servidor.
+  - "Aplicar filtros" -> `loadPessoas(filters)` **sem** o segundo argumento — cai no branch de cache, ou seja, filtrar por centro de servico/setor/cargo/tipo de execucao/periodo/termo ao clicar em "Aplicar" normalmente **nao gera nenhuma chamada ao Supabase**, so refiltra o que ja esta em memoria.
+  - "Limpar" -> mesmo comportamento de cache.
+  - Apos criar/editar/cancelar/importar pessoa -> `loadPessoas(filters, true)` (forca, pois os dados realmente mudaram).
+- Paginacao: nenhuma — `pessoasOrdenadas` (`sortPessoasByNome` sobre `pessoas`) e renderizada por completo.
+- Detalhe de codigo morto: `buildPessoasQuery` (`src/utils/pessoasUtils.js`) e um stub que sempre retorna `{}` com o comentario "filtros aplicados apenas no frontend" — e importado mas nunca chamado; o objeto `filters` bruto e passado direto para `listPessoas`.
+- Quando o servidor e de fato consultado (carga forcada): `api.pessoas.list(params)` resolve nomes de centro/setor/cargo/tipo de execucao para id via RPC `rpc_catalog_resolve`, monta a query sobre a RPC `rpc('rpc_pessoas_completa')` com `.eq` nesses ids + `.eq('ativo', ...)` + range de `criadoEm` + busca por `termo`, e busca tudo via `executePaged` (blocos de 1000 linhas).
+- Escopo de tenant especifico desta tela: `resolvePessoasOwnerScope()` (`src/services/api.js`) adiciona um `.in('centro_servico_id', ownerScope.centroServicoIds)` para contas nao-master, alem da RLS — nenhuma das outras 4 telas com escopo (Entradas/Saidas/Materiais/Estoque) tem essa camada extra no app.
+- Auxiliares: `referencias` (centros de servico/setores/cargos/tipos de execucao) via `listPessoasReferences()`, com fallback extraido da propria lista de pessoas quando as referencias voltam vazias para usuarios dependentes.
+
+Materiais
+---------
+- Pagina: `src/pages/Materiais.jsx`, dentro de `MateriaisProvider` -> `useMateriaisContext()` -> `useMateriaisController()` (`src/hooks/useMateriaisController.js`).
+- Estado: `materiais`/`materiaisBase` (lista completa) e `materiaisFiltrados` (lista exibida).
+- Carga inicial: `useEffect(() => { loadMateriais() }, [loadMateriais])` — carga simples no mount, sem depender de `userScopeKey` (unica das 7 telas sem esse guard explicito de troca de tenant). Um segundo `useEffect` carrega em paralelo os catalogos de grupo/fabricante/caracteristica/cor/calcado/tamanho.
+- `loadMateriais()`: chama `listMateriaisDetalhado()` **sem nenhum parametro** (sempre busca tudo), guarda em `materiais`/`materiaisBase` e ja aplica `filterMateriais(lista, MATERIAIS_FILTER_DEFAULT, {...})` para popular `materiaisFiltrados` com os defaults.
+- Gatilhos de recarga: botao "Atualizar" (`handleRefresh` -> `loadMateriais()`) e apos criar/editar material — sempre uma recarga completa (sem atualizacao incremental do item alterado).
+- Filtragem: 100% client-side, mesmo padrao de Acidentes — "Aplicar filtros" chama `filterMateriais(materiaisBase, filters, {...})` sobre a lista ja carregada, sem nenhuma chamada de rede; "Limpar" refiltra `materiaisBase` com os defaults.
+- Paginacao: nenhuma — `materiaisOrdenados` e renderizado por completo; o hook ainda expoe um `setCurrentPage: () => {}` (no-op), evidenciando que a paginacao nunca foi de fato conectada nesta tela.
+- Servico: `src/services/materiaisService.js` -> `listMateriaisDetalhado`, `getMaterial`, `createMaterial`/`updateMaterial`, `priceHistory`, `listGrupos`/`listFabricantes`/`listCaracteristicas`/`listCores`/`listCalcados`/`listTamanhos`/`listItensDoGrupo`.
+- Backend: `materiais.list()` e `materiais.listDetalhado()` sao a mesma implementacao (`carregarMateriais`/`carregarMateriaisDetalhados`) -> `supabase.from('materiais_view').select(MATERIAL_SELECT_COLUMNS).order('nome')`; nenhum aceita filtro/`.range()` do servidor. Catalogos (`grupos_material`, `caracteristica_epi`, `cor`, `medidas_calcado`, `medidas_vestimentas`, `grupos_material_itens`, `fabricantes`) sao tabelas simples com `.select().order()`. Autocomplete de material (`materiais.search`) usa `.or(<ilike>)` sobre `materiais_view` (ou `entradas_material_view` quando ha centro de estoque), com `.limit()` — mas isso e so para busca pontual, nao para a lista principal da tela.
+- Auxiliares: catalogos de grupo/fabricante/caracteristica/cor/calcado/tamanho carregados em paralelo no mount; `materialItems` recarrega em cascata sempre que `form.grupoMaterialId` muda (select dependente).
+
+Estoque Atual
+-------------
+- Pagina: `src/pages/EstoquePage.jsx`, dentro de `EstoqueProvider` -> `useEstoqueContext()`. Diferente das demais telas, o Context (`src/context/EstoqueContext.jsx`) compoe **dois hooks** em vez de um controller unico: `useEstoque()` (busca/cache de dados) e `useEstoqueFiltro()` (filtro/paginacao client-side).
+- `useEstoque()` (`src/hooks/useEstoque.js`):
+  - Estado: `estoque` (visao atual, pode estar em modo "movimentacao do periodo") e `estoqueBase` (saldo fisico acumulado).
+  - Carga inicial: guarda de modulo `hasRunInitialLoad` + `initRef` dentro de um `useEffect` de mount garantem `load({...initialFilters}, {force:true})` uma unica vez, mesmo com o duplo-invoke do StrictMode.
+  - Cache de chave de filtros (a mesma citada em `docs/Estoque.txt`): `baseKey`/`viewKey` sao `JSON.stringify` dos parametros (removendo campos de periodo do `baseKey` via `normalizeBaseParams`). Se `!force` e as chaves batem com a ultima chamada, `load()` retorna sem chamar o servidor. Mesmo quando a `viewKey` muda (ex.: so o periodo mudou), o `baseData` e reaproveitado de `estoqueBaseRef.current` se `baseKey` nao mudou — ou seja, ligar/desligar "Movimentacao do periodo" ou trocar so as datas nao refaz a busca de materiais/entradas/saidas completa, so a parte de "view". Ha ainda um `JSON.stringify` comparando o resultado novo com o atual antes de chamar `setEstoque`, evitando re-render quando o payload e identico.
+  - Este cache e de **deduplicacao** (evita repetir a mesma chamada), diferente do cache de Pessoas, que **reaproveita a mesma lista completa entre filtros diferentes** sem nunca mais rebuscar ate uma acao forcar.
+- Gatilhos de recarga: "Atualizar" e "Aplicar filtros" chamam `EstoqueContext.applyFilters()`, que sempre usa `{force:true}` (ou seja, a UI sempre ignora o cache de deduplicacao ao clicar nos botoes — o cache so evita chamadas redundantes automaticas, como remounts do StrictMode); o checkbox "Movimentacao do periodo" tambem dispara `applyFilters()` na hora; salvar estoque minimo (`handleMinStockSave`) tambem forca `load({...filters}, {force:true})`.
+- `api.estoque.current(params)` nao e uma tabela/RPC dedicada: busca `carregarMateriais()`, `carregarEntradas(params)` e `carregarSaidas(params)` em paralelo e combina tudo em JS via `montarEstoqueAtual(materiais, entradas, saidas, periodo, {...})` (`src/lib/estoque.js`), calculando `quantidade = totalEntradas - totalSaidas` por material e montando os campos de alerta/deficit.
+- Filtragem hibrida: como `params` e repassado para `carregarEntradas`/`carregarSaidas`, filtros de `centroCusto`/`termo`/periodo ja restringem as linhas buscadas no Supabase (o que muda quais materiais aparecem com movimentacao no agregado). Depois, `filterEstoqueItens` (`src/utils/estoqueUtils.js`, usado dentro de `useEstoqueFiltro.js`) refiltra o array `itens` resultante **inteiramente no cliente**: `termo`, `centroCusto` (de novo), `quantidadeMax`, `estoqueMinimo`, `apenasAlertas`, `apenasSaidas`, `apenasZerado` — nenhum desses ultimos tem equivalente no servidor.
+- Paginacao: client-side, duas independentes — Alertas (`ALERTAS_PAGE_SIZE = 6`) e Itens (`ITENS_PAGE_SIZE = 10`), ambas via `slice` em `useEstoqueFiltro.js`; `EstoquePage.jsx` tambem fixa `pageSize={10}` em `<EstoqueList>`.
+- Servico: `src/services/estoqueApi.js` -> `listEstoqueAtual(params) => api.estoque.current(params)`; tambem expoe `fetchEstoqueForecast`/`updateEstoqueForecast` (usados pela tela de Analise de Estoque, nao por esta).
+- Auxiliares: `centrosCustoDisponiveis` (opcoes de filtro) sao mineradas do proprio array `itens` ja calculado (`estoque.itens.flatMap(item => item.centrosCusto)`), sem busca separada. Salvar estoque minimo reusa `materiaisService.js` -> `api.materiais.update(id, payload)`.
+
+Boas praticas
+-------------
+- Ao criar uma nova tela com lista, decidir explicitamente se o filtro sera resolvido no servidor (como ASO) ou no cliente sobre uma carga unica (como Acidentes/Materiais); evitar o padrao hibrido "filtra nos dois lados" de Entradas/Saidas quando nao for estritamente necessario, pois ele exige manter duas implementacoes de filtro sincronizadas.
+- Se o dataset puder crescer bastante (Materiais, Estoque), considerar paginacao real no servidor (`.range()`) em vez de sempre carregar tudo e paginar so na tela.
+- Reaproveitar o padrao de cache de Estoque (`lastLoadKeyRef`/`lastBaseKeyRef`) para evitar chamadas duplicadas em telas que recebem multiplos `useEffect` reagindo aos mesmos filtros.
+- Ao adicionar cache de lista completa (como em Pessoas), garantir que toda acao que muda os dados no backend (criar/editar/excluir/importar) force `refreshOptions`/`force: true`, senao a tela pode continuar mostrando dado desatualizado do cache.
+
+Melhoria possivel
+-----------------
+- Remover ou implementar de fato `buildPessoasQuery` (`src/utils/pessoasUtils.js`), hoje um stub morto que sempre retorna `{}`.
+- Conectar a paginacao em Materiais (o `setCurrentPage: () => {}` hoje e um no-op) caso a lista de materiais cresca o suficiente para justificar.
+- Unificar a filtragem "dupla" de Entradas e Saidas (servidor + cliente) em uma unica fonte de verdade, para reduzir o risco de os dois filtros divergirem com o tempo.
+
+Atualizacao 2026-07
+--------------------
+- Documento criado apos auditoria de codigo do pipeline de carregamento de lista das 7 telas com CRUD principal (Acidentes, ASO, Entradas, Saidas, Pessoas, Materiais, Estoque Atual).
+- Nenhuma alteracao de codigo foi feita nesta auditoria.
+- Arquivos revisados:
+  - src/services/dataClient.js, src/config/runtime.js, src/services/api.js, src/services/localApi.js, src/config/pagination.js
+  - src/hooks/useAcidentes.js, src/hooks/useAcidenteFiltro.js, src/hooks/useAsoController.js
+  - src/hooks/useEntradasController.js, src/hooks/useSaidasController.js, src/hooks/usePessoasController.js, src/hooks/useMateriaisController.js
+  - src/hooks/useEstoque.js, src/hooks/useEstoqueFiltro.js, src/context/EstoqueContext.jsx
+  - src/pages/Acidentes.jsx, src/pages/AsoPage.jsx, src/pages/EntradasPage.jsx, src/pages/SaidasPage.jsx, src/pages/Pessoas.jsx, src/pages/Materiais.jsx, src/pages/EstoquePage.jsx
+  - src/services/acidentesService.js, src/services/asoService.js, src/services/entradasService.js, src/services/saidasService.js, src/services/pessoasService.js, src/services/materiaisService.js, src/services/estoqueApi.js

--- a/docs/DashboardAcidentes.txt
+++ b/docs/DashboardAcidentes.txt
@@ -146,3 +146,11 @@ Atualizacao 2026-02
 - Cores das barras padronizadas com o grafico de top materiais (#22d3ee) em Parte lesionada, Lesoes e Acidentes por cargo.
 - ChartAgentes (src/components/charts/ChartAgentes.jsx): grafico voltou para rosca com paleta baseada no azul do Top materiais.
 - ChartAgentes (src/components/charts/ChartAgentes.jsx): paleta alinhada com o grafico Top categorias (estoque).
+
+Atualizacao 2026-08
+-------------------
+- Diagnostico: havia 5 registros ativos de HHT em 03/2026 para o owner da Fabiana, totalizando 99.120,67, mas os 24 acidentes de 2026 estavam em meses/centros sem correspondencia exata; a regra anterior somava HHT apenas quando existia acidente no mesmo mes e centro.
+- Antes: `src/lib/acidentesDashboard.js` calculava `hht_total` reduzindo a lista filtrada de acidentes e chamando `resolveHhtAcidente`, o que retornava 0 quando o acidente nao tinha HHT legado e nao casava com `hht_mensal`.
+- Depois: `src/lib/acidentesDashboard.js` soma os registros ativos de `hht_mensal` dentro do periodo/centro filtrado, independente de haver acidente no mesmo centro/mes; o fallback remoto passa a buscar `centro_servico_id` em `hht_mensal_view`.
+- Banco: criada a migration `supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql` para recriar `vw_indicadores_acidentes` com HHT mensal agregado por periodo/tenant, usando `security_invoker = on` e coluna `account_owner_id`.
+- Multi-tenant: a view passa a agrupar por `account_owner_id` e depende de RLS nas tabelas base; usuarios comuns continuam restritos ao proprio tenant.

--- a/docs/ExportacaoExcel.txt
+++ b/docs/ExportacaoExcel.txt
@@ -1,0 +1,102 @@
+Exportacao para Excel (CSV)
+===========================
+
+Visao geral
+-----------
+- O botao "Exportar Excel (CSV)" existe em 7 telas: Acidentes, ASO, Entradas, Saidas, Pessoas, Materiais e Estoque Atual.
+- Nao ha geracao de arquivo .xlsx real (nao ha lib `xlsx`/`exceljs`/SheetJS no projeto). O botao gera um CSV (texto separado por `;`) e forca o download com extensao `.csv`; o rotulo "Excel" e apenas indicativo de que o Excel consegue abrir o arquivo.
+- Cada tela usa a mesma logica geral, duplicada por modulo (nao ha um util generico compartilhado):
+  1. Um `sanitizeCsvValue` local trata `null/undefined`, escapa aspas (`"` -> `""`), remove quebras de linha e envolve em aspas quando o valor contem `;`, `"` ou `\n`.
+  2. Um `buildXCsv(lista, contexto?)` monta o cabecalho + linhas (`;` como separador de campo, `\n` como separador de linha).
+  3. Um `downloadXCsv(lista, contexto?, options)` cria o `Blob`, monta um link `<a download>` temporario, dispara `click()` e revoga a URL do objeto.
+- O `handleExportCsv` de cada pagina sempre usa a lista ja filtrada/ordenada em memoria (useMemo), nao a lista bruta nem uma pagina especifica de paginacao — ou seja, exporta todos os registros que atendem aos filtros aplicados na tela, independente de paginacao visual.
+- Nao existem testes automatizados (unit/integration) cobrindo os builders/downloads de CSV em nenhuma das 7 telas.
+
+Arquitetura por tela
+--------------------
+- Acidentes
+  - Botao: `src/pages/Acidentes.jsx:247` (handler `handleExportCsv`, linha 65).
+  - Fonte de dados: `acidentesFiltrados` (`src/hooks/useAcidenteFiltro.js:38`).
+  - Builder/download: `src/utils/acidentesExport.js` (`buildAcidentesCsv` / `downloadAcidentesCsv`).
+  - Nome do arquivo: `acidentes-AAAA-MM-DD.csv` (data via `toISOString().slice(0,10)`, portanto em UTC).
+  - Colunas: Nome, Matricula, Status (Ativo/Cancelado conforme `ativo`), Data, Centro de servico, Local, CAT, CID, Registrado por, Cadastrado em.
+- ASO
+  - Botao: `src/pages/AsoPage.jsx:125` (handler `handleExportCsv`, linha 69).
+  - Fonte de dados: `asos` (estado carregado da tela, ja filtrado pelo backend).
+  - Builder/download: `src/utils/asoExport.js` (`buildAsoCsv` / `downloadAsoCsv`).
+  - Nome do arquivo: `controle-de-aso-AAAA-MM-DD.csv` (UTC).
+  - Colunas: ID, Funcionario, Matricula, Tipo de exame, Data do exame, Proximo vencimento, Dias para vencer, Status, Centro de servico, Setor, Cargo, Observacao, Cadastrado em, Atualizado em.
+- Entradas
+  - Botao: `src/pages/EntradasPage.jsx:343` (handler `handleExportCsv`, linha 164).
+  - Fonte de dados: `filteredEntradas` (`src/hooks/useEntradasController.js:642`), mais `materiaisMap`/`centrosCustoMap` para resolver nomes.
+  - Builder/download: `src/utils/entradasExport.js` (`buildEntradasCsv` / `downloadEntradasCsv`).
+  - Nome do arquivo: `entradas-AAAA-MM-DD.csv` (UTC).
+  - Colunas: ID, Centro de estoque, Material, Descricao, Quantidade, Status, Registrado por, Cadastrado em.
+- Saidas
+  - Botao: `src/pages/SaidasPage.jsx:422` (handler `handleExportCsv`, linha 134).
+  - Fonte de dados: `saidasFiltradas` (`src/hooks/useSaidasController.js:757`), com mapas montados na hora (`pessoasMap`, `materiaisMap`, `centrosEstoqueMap`) a partir de `pessoas`/`materiais`/`centrosEstoqueOptions` do estado da pagina.
+  - Builder/download: `src/utils/saidasExport.js` (`buildSaidasCsv` / `downloadSaidasCsv`).
+  - Nome do arquivo: `saidas-AAAA-MM-DD.csv` (UTC).
+  - Colunas: ID, Pessoa, Matricula, Material, Quantidade, Centro de estoque, Centro de custo, Centro de servico, Data entrega, Data troca, Status, Registrado por, Cadastrado em.
+- Pessoas
+  - Botao: `src/pages/Pessoas.jsx:127` (handler `handleExportCsv`, linha 75).
+  - Fonte de dados: `pessoasOrdenadas` (`src/hooks/usePessoasController.js:502`, ordenado por nome).
+  - Builder/download: `src/utils/pessoasUtils.js` (`buildPessoasCsv` / `downloadPessoasCsv`).
+  - Nome do arquivo: `pessoas-AAAA-MM-DD.csv` (UTC).
+  - Colunas: ID, Nome, Matricula, Centro de servico, Setor, Cargo, Tipo de execucao, Data admissao, Data demissao, Status (ATIVO/INATIVO), Usuario cadastro, Usuario edicao, Criado em, Atualizado em.
+- Materiais
+  - Botao: `src/pages/Materiais.jsx:161` (handler `handleExportCsv`, linha 83).
+  - Fonte de dados: `materiaisOrdenados` (`src/hooks/useMateriaisController.js:655`, sobre `materiaisFiltrados`).
+  - Builder/download: `src/utils/MateriaisUtils.js` (`buildMateriaisCsv` / `downloadMateriaisCsv`).
+  - Nome do arquivo: `materiais-AAAA-MM-DD.csv` (data local, montada manualmente com `getFullYear/getMonth/getDate`, ao contrario das demais telas que usam `toISOString`).
+  - Colunas: ID, CA, Grupo, Material, Descricao, Valor unitario, Validade (dias), Fabricante, Registrado por, Cadastrado em.
+- Estoque Atual
+  - Botao: `src/pages/EstoquePage.jsx:115` (handler `handleExportCsv`, linha 53).
+  - Fonte de dados: `itensFiltradosBase` (`src/hooks/useEstoqueFiltro.js:28`), que aplica os filtros sobre `estoqueBase` (saldo fisico acumulado), e nao sobre `estoque` (que pode estar em modo "Movimentacao do periodo"). Ou seja, o CSV sempre exporta a posicao acumulada, mesmo com o toggle de periodo ligado na tela.
+  - Builder/download: `src/utils/estoqueUtils.js` (`buildEstoqueCsv` / `downloadEstoqueCsv`).
+  - Nome do arquivo: `estoque-atual-AAAA-MM-DD.csv` (data local, mesma abordagem manual de Materiais).
+  - Colunas: Material ID, Material, Fabricante, CA, Cor, Validade (dias), Centros de estoque, Quantidade em estoque, Total de entradas, Total de saidas, Estoque minimo, Deficit, Valor unitario, Valor total, Valor para reposicao, Ultima atualizacao, Ultima saida (data).
+
+Formato do arquivo gerado
+-------------------------
+- Separador de campo: `;` (ponto e virgula) em todas as telas — compativel com o separador padrao do Excel em locale pt-BR.
+- Separador de linha: `\n`.
+- MIME type do Blob: `text/csv;charset=utf-8;` em todas as telas.
+- Escape de valores: aspas duplicadas (`""`) e valor entre aspas quando contem `;`, `"` ou quebra de linha; quebras de linha internas viram espaco.
+- Numeros: quando existe `formatCsvNumber` (Materiais e Estoque), o separador decimal e ponto (`.`), nao virgula. Como o Excel pt-BR normalmente espera virgula como separador decimal, colunas numericas (ex.: "Valor unitario", "Valor total") podem abrir como texto em vez de numero, dependendo do locale do Excel do usuario.
+- Datas: formatadas via `toLocaleString('pt-BR')`/`toLocaleDateString('pt-BR')` ou helpers especificos de cada dominio (`formatDisplayDateTime`, `formatDateWithOptionalTime` etc.), portanto ja chegam como texto no formato dd/mm/aaaa (hh:mm quando aplicavel).
+
+Inconsistencias identificadas (verificacao de codigo)
+------------------------------------------------------
+- BOM UTF-8 (`﻿`) ausente em 3 das 7 telas:
+  - Com BOM: `acidentesExport.js`, `asoExport.js`, `entradasExport.js`, `saidasExport.js` (prefixam o conteudo do Blob com `﻿`).
+  - Sem BOM: `MateriaisUtils.js`, `pessoasUtils.js`, `estoqueUtils.js` (`downloadMateriaisCsv`, `downloadPessoasCsv`, `downloadEstoqueCsv` criam o Blob direto de `csvContent`, sem `﻿`).
+  - Efeito pratico: ao abrir o CSV de Materiais, Pessoas ou Estoque Atual direto no Excel (duplo clique), caracteres acentuados (ex.: "Validade", "Descricao", "Ultima saida") tendem a aparecer corrompidos (mojibake), pois o Excel sem BOM assume a codificacao ANSI/locale em vez de UTF-8. Nas outras 4 telas (Acidentes, ASO, Entradas, Saidas) o BOM evita esse problema.
+- Linha de dica `sep=;` (forca o Excel a reconhecer o delimitador na abertura direta) presente apenas em ASO, Entradas e Saidas (`buildAsoCsv`, `buildEntradasCsv`, `buildSaidasCsv` retornam `['sep=;', headers..., ...rows]`). Ausente em Acidentes, Materiais, Pessoas e Estoque Atual.
+- Padrao de nome de arquivo/data diferente entre telas:
+  - Acidentes, ASO, Entradas, Saidas usam `new Date().toISOString().slice(0, 10)` (data em UTC — pode divergir do dia local do usuario perto da meia-noite).
+  - Materiais e Estoque Atual montam a data manualmente a partir de `getFullYear/getMonth/getDate` (data local).
+  - Pessoas usa o mesmo padrao UTC de Acidentes/ASO/Entradas/Saidas.
+- Cada tela reimplementa seu proprio `sanitizeCsvValue`/`formatCsvNumber`/`formatCsvDate` (7 copias quase identicas espalhadas por `src/utils/*`), sem um modulo `csvUtils` compartilhado — risco de divergencia caso a regra de escaping precise mudar no futuro (ja ha divergencia no BOM e no `sep=;` acima).
+
+Boas praticas
+-------------
+- Ao adicionar uma nova tela com exportacao, seguir o padrao com BOM (`﻿`) + linha `sep=;` para evitar os problemas de acentuacao/delimitador ja mapeados acima.
+- Exportar sempre a partir da lista ja filtrada em memoria (`useMemo`), nunca da lista bruta, para manter consistencia com o que o usuario ve na tela.
+- Ao exportar valores monetarios/numericos, considerar formatar com virgula (`toLocaleString('pt-BR')`) em vez de ponto, para abrir corretamente como numero no Excel pt-BR.
+
+Melhoria possivel
+-----------------
+- Corrigir a ausencia de BOM em `MateriaisUtils.js`, `pessoasUtils.js` e `estoqueUtils.js` (adicionar `﻿` no Blob), alinhando com as demais 4 telas.
+- Adicionar a linha `sep=;` em `acidentesExport.js`, `MateriaisUtils.js`, `pessoasUtils.js` e `estoqueUtils.js` para garantir abertura direta no Excel com o delimitador correto em qualquer locale.
+- Extrair um `src/utils/csvExport.js` compartilhado (sanitize, montagem do Blob/link, download) para eliminar a duplicacao entre as 7 implementacoes e evitar que futuras correcoes fiquem parciais (como a atual divergencia de BOM/sep=;).
+- Considerar gerar um `.xlsx` real (ex.: via SheetJS) se for necessario preservar tipos de coluna (numero/data) sem depender do locale do Excel do usuario.
+
+Atualizacao 2026-07
+--------------------
+- Documento criado apos auditoria de codigo das 7 telas com botao "Exportar Excel (CSV)" (Acidentes, ASO, Entradas, Saidas, Pessoas, Materiais, Estoque Atual).
+- Nenhuma alteracao de codigo foi feita nesta auditoria; achados registrados na secao "Inconsistencias identificadas" acima para correcao futura.
+- Arquivos revisados:
+  - src/pages/Acidentes.jsx, src/pages/AsoPage.jsx, src/pages/EntradasPage.jsx, src/pages/SaidasPage.jsx, src/pages/Pessoas.jsx, src/pages/Materiais.jsx, src/pages/EstoquePage.jsx
+  - src/utils/acidentesExport.js, src/utils/asoExport.js, src/utils/entradasExport.js, src/utils/saidasExport.js, src/utils/MateriaisUtils.js, src/utils/pessoasUtils.js, src/utils/estoqueUtils.js
+  - src/hooks/useAcidenteFiltro.js, src/hooks/useEntradasController.js, src/hooks/useSaidasController.js, src/hooks/usePessoasController.js, src/hooks/useMateriaisController.js, src/hooks/useEstoqueFiltro.js

--- a/src/lib/acidentesDashboard.js
+++ b/src/lib/acidentesDashboard.js
@@ -278,6 +278,90 @@ function buildHhtMap(hhtMensal = []) {
   return mapa
 }
 
+function resolveHhtPeriodo(item) {
+  const rawPeriodo = item?.mesRef ?? item?.mes_ref ?? ''
+  if (rawPeriodo instanceof Date) {
+    return rawPeriodo.toISOString().slice(0, 7)
+  }
+  const texto = String(rawPeriodo || '').trim()
+  if (/^\d{4}-\d{2}$/.test(texto)) {
+    return texto
+  }
+  if (/^\d{4}-\d{2}-\d{2}/.test(texto) || (texto.includes('T') && /^\d{4}-\d{2}/.test(texto))) {
+    return texto.slice(0, 7)
+  }
+  return sanitizeMonth(texto)
+}
+
+function isHhtAtivo(item) {
+  if (item?.ativo === false || item?.is_active === false) {
+    return false
+  }
+  const status = normalizeKey(
+    item?.statusNome ??
+      item?.status_nome ??
+      item?.status ??
+      item?.statusHht ??
+      item?.status_hht ??
+      item?.status_hht_nome ??
+      '',
+  )
+  return status !== 'cancelado'
+}
+
+function resolveHhtCentro(item) {
+  return normalizeKey(
+    item?.centroServicoNome ??
+      item?.centroServico ??
+      item?.centro_servico_nome ??
+      item?.centro_servico ??
+      '',
+  )
+}
+
+function filterHhtMensal(hhtMensal = [], periodoInicio, periodoFim, centroServicoFiltro) {
+  const inicio = sanitizeMonth(periodoInicio)
+  const fim = sanitizeMonth(periodoFim)
+  const centroFiltro = normalizeKey(centroServicoFiltro)
+
+  return (Array.isArray(hhtMensal) ? hhtMensal : []).filter((item) => {
+    if (!isHhtAtivo(item)) {
+      return false
+    }
+    const periodo = resolveHhtPeriodo(item)
+    if (!periodo) {
+      return false
+    }
+    if (inicio && periodo < inicio) {
+      return false
+    }
+    if (fim && periodo > fim) {
+      return false
+    }
+    if (centroFiltro && resolveHhtCentro(item) !== centroFiltro) {
+      return false
+    }
+    const valor = toNumber(item?.hhtFinal ?? item?.hht_final ?? item?.hhtCalculado ?? item?.hht_calculado)
+    return Number.isFinite(valor) && valor >= 0
+  })
+}
+
+function buildHhtPeriodoMap(hhtMensal = []) {
+  const mapa = new Map()
+  ;(Array.isArray(hhtMensal) ? hhtMensal : []).forEach((item) => {
+    const periodo = resolveHhtPeriodo(item)
+    if (!periodo) {
+      return
+    }
+    const valor = toNumber(item?.hhtFinal ?? item?.hht_final ?? item?.hhtCalculado ?? item?.hht_calculado)
+    if (!Number.isFinite(valor) || valor < 0) {
+      return
+    }
+    mapa.set(periodo, (mapa.get(periodo) ?? 0) + valor)
+  })
+  return mapa
+}
+
 function resolveHhtAcidente(acidente, hhtMap) {
   const data = parseIsoDate(acidente?.data)
   if (!data) {
@@ -292,7 +376,7 @@ function resolveHhtAcidente(acidente, hhtMap) {
   return toNumber(acidente?.hht)
 }
 
-function montarTendencia(acidentes, periodoInicio, periodoFim, hhtMap) {
+function montarTendencia(acidentes, periodoInicio, periodoFim, hhtMap, hhtPeriodoMap = null) {
   const mapa = new Map()
 
   acidentes.forEach((acidente) => {
@@ -312,10 +396,12 @@ function montarTendencia(acidentes, periodoInicio, periodoFim, hhtMap) {
     const grupo = mapa.get(periodo)
     grupo.total_acidentes += 1
     grupo.dias_perdidos += toNumber(acidente?.diasPerdidos)
-    grupo.hht_total += resolveHhtAcidente(acidente, hhtMap)
+    if (!hhtPeriodoMap) {
+      grupo.hht_total += resolveHhtAcidente(acidente, hhtMap)
+    }
   })
 
-  const periodosDisponiveis = Array.from(mapa.keys()).sort(comparePeriodos)
+  const periodosDisponiveis = Array.from(new Set([...mapa.keys(), ...Array.from(hhtPeriodoMap?.keys?.() ?? [])])).sort(comparePeriodos)
 
   let inicio = sanitizeMonth(periodoInicio)
   let fim = sanitizeMonth(periodoFim)
@@ -350,7 +436,9 @@ function montarTendencia(acidentes, periodoInicio, periodoFim, hhtMap) {
       dias_perdidos: 0,
       hht_total: 0,
     }
-    const { total_acidentes, dias_perdidos, hht_total } = grupo
+    const total_acidentes = grupo.total_acidentes
+    const dias_perdidos = grupo.dias_perdidos
+    const hht_total = hhtPeriodoMap ? toNumber(hhtPeriodoMap.get(periodo), 0) : grupo.hht_total
     const taxa_frequencia = hht_total > 0 ? Number(((total_acidentes * TAXA_BASE) / hht_total).toFixed(2)) : 0
     const taxa_gravidade = hht_total > 0 ? Number(((dias_perdidos * TAXA_BASE) / hht_total).toFixed(2)) : 0
 
@@ -386,6 +474,8 @@ export function montarDashboardAcidentes(acidentes = [], filtros = {}, hhtMensal
     (item) => item?.ativo !== false
   )
   const hhtMap = buildHhtMap(hhtMensal)
+  const hhtFiltrado = filterHhtMensal(hhtMensal, periodoInicio, periodoFim, filtros.centroServico)
+  const hhtPeriodoMap = Array.isArray(hhtMensal) ? buildHhtPeriodoMap(hhtFiltrado) : null
 
   const filtradosPorPeriodo = acidentesValidos.filter((acidente) => {
     const data = parseIsoDate(acidente?.data)
@@ -447,7 +537,9 @@ export function montarDashboardAcidentes(acidentes = [], filtros = {}, hhtMensal
 
   const totalAcidentes = listaFiltrada.length
   const diasPerdidos = listaFiltrada.reduce((total, acidente) => total + toNumber(acidente?.diasPerdidos), 0)
-  const hhtTotal = listaFiltrada.reduce((total, acidente) => total + resolveHhtAcidente(acidente, hhtMap), 0)
+  const hhtTotal = hhtPeriodoMap
+    ? Array.from(hhtPeriodoMap.values()).reduce((total, valor) => total + toNumber(valor), 0)
+    : listaFiltrada.reduce((total, acidente) => total + resolveHhtAcidente(acidente, hhtMap), 0)
   const totalAcidentesComAfastamento = listaFiltrada.filter((acidente) => toNumber(acidente?.diasPerdidos) > 0).length
   const totalAcidentesSemAfastamento = listaFiltrada.filter((acidente) => toNumber(acidente?.diasPerdidos) === 0).length
 
@@ -466,7 +558,7 @@ export function montarDashboardAcidentes(acidentes = [], filtros = {}, hhtMensal
     periodo_label: buildPeriodoLabel(periodoInicio, periodoFim),
   }
 
-  const tendencia = montarTendencia(listaFiltrada, periodoInicio, periodoFim, hhtMap)
+  const tendencia = montarTendencia(listaFiltrada, periodoInicio, periodoFim, hhtMap, hhtPeriodoMap)
   const tipos = distribuirPorChave(
     listaFiltrada,
     (item) => item?.tipos ?? item?.tipo,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -7139,7 +7139,7 @@ export const api = {
         const dadosHht = await execute(
           supabase
             .from('hht_mensal_view')
-            .select('mes_ref, centro_servico_nome, hht_final, status_nome'),
+            .select('mes_ref, centro_servico_id, centro_servico_nome, hht_final, status_nome'),
           'Falha ao listar HHT mensal para dashboard.'
         )
         const lista = Array.isArray(dadosHht) ? dadosHht : []

--- a/supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql
+++ b/supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql
@@ -1,0 +1,425 @@
+-- Corrige o Dashboard de Acidentes para somar HHT mensal ativo do periodo,
+-- mesmo quando nao ha acidente no mesmo centro/mes.
+
+drop view if exists public.vw_indicadores_acidentes;
+
+create view public.vw_indicadores_acidentes
+with (security_invoker = on) as
+with acidentes_base as (
+  select
+    a.account_owner_id,
+    a.id,
+    a.accident_date,
+    a.lost_days,
+    a.debited_days,
+    p.matricula,
+    p.nome as pessoa_nome,
+    cg.nome as cargo,
+    cs.nome as centro_servico_nome,
+    lower(trim(cs.nome)) as unidade_key
+  from public.accidents a
+  left join public.pessoas p on p.id = a.people_id
+  left join public.cargos cg on cg.id = p.cargo_id
+  left join public.centros_servico cs on cs.id = a.service_center
+  where a.accident_date is not null
+    and coalesce(a.is_active, true) = true
+    and coalesce(a.cancel_reason, '') is distinct from '__cancel_placeholder__'
+),
+agentes_agg as (
+  select
+    aga.accident_id,
+    array_remove(
+      array_agg(distinct coalesce(nullif(trim(aa.nome), ''), 'Nao informado')),
+      ''
+    ) as agentes_array
+  from public.accident_group_agents aga
+  left join public.acidente_agentes aa on aa.id = aga.accident_agents_id
+  group by aga.accident_id
+),
+tipos_agg as (
+  select
+    aga.accident_id,
+    array_remove(
+      array_agg(distinct coalesce(nullif(trim(at.nome), ''), 'Nao informado')),
+      ''
+    ) as tipos_array
+  from public.accident_group_agents aga
+  left join public.acidente_tipos at on at.id = aga.accident_type_id
+  group by aga.accident_id
+),
+lesoes_agg as (
+  select
+    aga.accident_id,
+    array_remove(
+      array_agg(distinct coalesce(nullif(trim(al.nome), ''), 'Nao informado')),
+      ''
+    ) as lesoes_array
+  from public.accident_group_agents aga
+  left join public.acidente_lesoes al on al.id = aga.accident_injuries_id
+  group by aga.accident_id
+),
+partes_agg as (
+  select
+    agp.accident_id,
+    array_remove(
+      array_agg(
+        distinct coalesce(
+          nullif(trim(concat_ws(' / ', pg.nome, sg.nome, ap.nome)), ''),
+          'Nao informado'
+        )
+      ),
+      ''
+    ) as partes_array
+  from public.accident_group_parts agp
+  join public.acidente_partes ap on ap.id = agp.accident_parts_id
+  left join public.acidente_partes_grupo pg on pg.id = ap.grupo
+  left join public.acidente_partes_sub_grupo sg on sg.id = ap.subgrupo
+  group by agp.accident_id
+),
+acidentes_norm as (
+  select
+    ab.account_owner_id,
+    ab.id,
+    date_part('year', ab.accident_date)::int as ano,
+    to_char(date_trunc('month', ab.accident_date), 'YYYY-MM') as periodo,
+    coalesce(nullif(trim(ab.centro_servico_nome), ''), 'Nao informado') as unidade,
+    coalesce(nullif(trim(ab.unidade_key), ''), 'nao informado') as unidade_key,
+    coalesce(nullif(trim(ab.cargo), ''), 'Nao informado') as cargo,
+    coalesce(nullif(tp.tipos_array, '{}'::text[]), array['Nao informado']) as tipos_array,
+    coalesce(nullif(ag.agentes_array, '{}'::text[]), array['Nao informado']) as agentes_array,
+    coalesce(nullif(pa.partes_array, '{}'::text[]), array['Nao informado']) as partes_array,
+    coalesce(nullif(le.lesoes_array, '{}'::text[]), array['Nao informado']) as lesoes_array,
+    coalesce(
+      nullif(lower(trim(ab.matricula)), ''),
+      nullif(lower(trim(ab.pessoa_nome)), ''),
+      ab.id::text
+    ) as pessoa_chave,
+    greatest(coalesce(ab.lost_days, 0)::numeric, 0)::numeric as dias_perdidos,
+    greatest(coalesce(ab.debited_days, 0)::numeric, 0)::numeric as dias_debitados
+  from acidentes_base ab
+  left join agentes_agg ag on ag.accident_id = ab.id
+  left join tipos_agg tp on tp.accident_id = ab.id
+  left join lesoes_agg le on le.accident_id = ab.id
+  left join partes_agg pa on pa.accident_id = ab.id
+),
+hht_norm as (
+  select
+    hm.account_owner_id,
+    date_part('year', hm.mes_ref)::int as ano,
+    to_char(date_trunc('month', hm.mes_ref), 'YYYY-MM') as periodo,
+    hm.centro_servico_id,
+    lower(trim(cs.nome)) as unidade_key,
+    sum(coalesce(hm.hht_final, 0)) as hht_total
+  from public.hht_mensal hm
+  join public.centros_servico cs on cs.id = hm.centro_servico_id
+  left join public.status_hht sh on sh.id = hm.status_hht_id
+  where coalesce(lower(trim(sh.status)), 'ativo') <> 'cancelado'
+  group by hm.account_owner_id, ano, periodo, hm.centro_servico_id, unidade_key
+),
+hht_periodo as (
+  select
+    account_owner_id,
+    ano,
+    periodo,
+    sum(hht_total)::numeric as hht_total
+  from hht_norm
+  group by account_owner_id, ano, periodo
+),
+hht_ano as (
+  select
+    account_owner_id,
+    ano,
+    sum(hht_total)::numeric as hht_total
+  from hht_periodo
+  group by account_owner_id, ano
+),
+anos as (
+  select distinct account_owner_id, ano from acidentes_norm
+  union
+  select distinct account_owner_id, ano from hht_periodo
+),
+acidentes_ano as (
+  select
+    account_owner_id,
+    ano,
+    count(*) as total_acidentes,
+    count(*) filter (where dias_perdidos > 0) as total_acidentes_afastamento,
+    count(*) filter (where coalesce(dias_perdidos, 0) = 0) as total_acidentes_sem_afastamento,
+    coalesce(sum(dias_perdidos), 0)::numeric as dias_perdidos,
+    coalesce(sum(dias_debitados), 0)::numeric as dias_debitados
+  from acidentes_norm
+  group by account_owner_id, ano
+),
+resumo as (
+  select
+    y.account_owner_id,
+    y.ano,
+    coalesce(aa.total_acidentes, 0) as total_acidentes,
+    coalesce(aa.total_acidentes_afastamento, 0) as total_acidentes_afastamento,
+    coalesce(aa.total_acidentes_sem_afastamento, 0) as total_acidentes_sem_afastamento,
+    coalesce(aa.dias_perdidos, 0)::numeric as dias_perdidos,
+    coalesce(aa.dias_debitados, 0)::numeric as dias_debitados,
+    coalesce(ha.hht_total, 0)::numeric as hht_total
+  from anos y
+  left join acidentes_ano aa on aa.account_owner_id = y.account_owner_id and aa.ano = y.ano
+  left join hht_ano ha on ha.account_owner_id = y.account_owner_id and ha.ano = y.ano
+),
+pessoas_totais as (
+  select
+    account_owner_id,
+    count(*)::numeric as total_trabalhadores
+  from public.pessoas
+  where ativo is true
+  group by account_owner_id
+),
+resumo_metricas as (
+  select
+    r.*,
+    case
+      when r.hht_total > 0 then round((r.total_acidentes::numeric * 1000000) / r.hht_total, 2)
+      else 0
+    end as taxa_frequencia_total,
+    case
+      when r.hht_total > 0 then round((r.total_acidentes_afastamento::numeric * 1000000) / r.hht_total, 2)
+      else 0
+    end as taxa_frequencia_afastamento,
+    case
+      when r.hht_total > 0 then round((r.total_acidentes_sem_afastamento::numeric * 1000000) / r.hht_total, 2)
+      else 0
+    end as taxa_frequencia_sem_afastamento,
+    case
+      when r.hht_total > 0 then round(((r.dias_perdidos + r.dias_debitados)::numeric * 1000000) / r.hht_total, 2)
+      else 0
+    end as taxa_gravidade_total
+  from resumo r
+),
+acidentes_por_periodo as (
+  select
+    account_owner_id,
+    ano,
+    periodo,
+    count(*) as total_acidentes,
+    sum(dias_perdidos) as dias_perdidos,
+    sum(dias_debitados) as dias_debitados
+  from acidentes_norm
+  group by account_owner_id, ano, periodo
+),
+periodos as (
+  select distinct account_owner_id, ano, periodo from acidentes_por_periodo
+  union
+  select distinct account_owner_id, ano, periodo from hht_periodo
+),
+tendencia_detalhe as (
+  select
+    p.account_owner_id,
+    p.ano,
+    p.periodo,
+    coalesce(ap.total_acidentes, 0) as total_acidentes,
+    coalesce(ap.dias_perdidos, 0)::numeric as dias_perdidos,
+    coalesce(ap.dias_debitados, 0)::numeric as dias_debitados,
+    coalesce(hp.hht_total, 0)::numeric as hht_total
+  from periodos p
+  left join acidentes_por_periodo ap
+    on ap.account_owner_id = p.account_owner_id and ap.ano = p.ano and ap.periodo = p.periodo
+  left join hht_periodo hp
+    on hp.account_owner_id = p.account_owner_id and hp.ano = p.ano and hp.periodo = p.periodo
+),
+tendencia as (
+  select
+    td.account_owner_id,
+    td.ano,
+    jsonb_agg(
+      jsonb_build_object(
+        'periodo', td.periodo,
+        'total_acidentes', td.total_acidentes,
+        'dias_perdidos', td.dias_perdidos,
+        'dias_debitados', td.dias_debitados,
+        'hht_total', td.hht_total,
+        'taxa_frequencia',
+          case
+            when td.hht_total > 0 then round((td.total_acidentes::numeric * 1000000) / td.hht_total, 2)
+            else 0
+          end,
+        'taxa_gravidade',
+          case
+            when td.hht_total > 0 then round(((td.dias_perdidos + td.dias_debitados)::numeric * 1000000) / td.hht_total, 2)
+            else 0
+          end
+      )
+      order by td.periodo asc
+    ) as tendencia
+  from tendencia_detalhe td
+  group by td.account_owner_id, td.ano
+),
+tipos as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('tipo', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as tipos
+  from (
+    select
+      an.account_owner_id,
+      an.ano,
+      coalesce(nullif(trim(valor), ''), 'Nao informado') as label,
+      count(*) as total
+    from acidentes_norm an
+    cross join lateral unnest(an.tipos_array) as valor
+    group by an.account_owner_id, an.ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+),
+agentes as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('agente', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as agentes
+  from (
+    select
+      an.account_owner_id,
+      an.ano,
+      coalesce(nullif(trim(valor), ''), 'Nao informado') as label,
+      count(*) as total
+    from acidentes_norm an
+    cross join lateral unnest(an.agentes_array) as valor
+    group by an.account_owner_id, an.ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+),
+partes as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('parte_lesionada', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as partes_lesionadas
+  from (
+    select
+      an.account_owner_id,
+      an.ano,
+      coalesce(nullif(trim(valor), ''), 'Nao informado') as label,
+      count(*) as total
+    from acidentes_norm an
+    cross join lateral unnest(an.partes_array) as valor
+    group by an.account_owner_id, an.ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+),
+lesoes as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('lesao', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as lesoes
+  from (
+    select
+      an.account_owner_id,
+      an.ano,
+      coalesce(nullif(trim(valor), ''), 'Nao informado') as label,
+      count(*) as total
+    from acidentes_norm an
+    cross join lateral unnest(an.lesoes_array) as valor
+    group by an.account_owner_id, an.ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+),
+cargos as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('cargo', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as cargos
+  from (
+    select
+      account_owner_id,
+      ano,
+      coalesce(nullif(trim(cargo), ''), 'Nao informado') as label,
+      count(*) as total
+    from acidentes_norm
+    group by account_owner_id, ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+),
+pessoas_centro as (
+  select
+    item.account_owner_id,
+    item.ano,
+    jsonb_agg(
+      jsonb_build_object('centro_servico', item.label, 'total', item.total)
+      order by item.total desc, item.label asc
+    ) as pessoas_por_centro
+  from (
+    select
+      account_owner_id,
+      ano,
+      coalesce(nullif(trim(unidade), ''), 'Nao informado') as label,
+      count(distinct pessoa_chave) as total
+    from acidentes_norm
+    where pessoa_chave is not null
+    group by account_owner_id, ano, label
+  ) item
+  group by item.account_owner_id, item.ano
+)
+select
+  rm.account_owner_id,
+  rm.ano,
+  'todas'::text as unidade,
+  jsonb_build_object(
+    'ano', rm.ano,
+    'periodo', rm.ano::text,
+    'periodo_label', concat('Ano ', rm.ano),
+    'total_acidentes', rm.total_acidentes,
+    'total_acidentes_afastamento', rm.total_acidentes_afastamento,
+    'total_acidentes_sem_afastamento', rm.total_acidentes_sem_afastamento,
+    'dias_perdidos', rm.dias_perdidos,
+    'dias_debitados', rm.dias_debitados,
+    'hht_total', rm.hht_total,
+    'taxa_frequencia', rm.taxa_frequencia_total,
+    'taxa_frequencia_afastamento', rm.taxa_frequencia_afastamento,
+    'taxa_frequencia_sem_afastamento', rm.taxa_frequencia_sem_afastamento,
+    'taxa_gravidade', rm.taxa_gravidade_total,
+    'indice_acidentados',
+      round(((rm.taxa_frequencia_total + rm.taxa_gravidade_total) / 100)::numeric, 2),
+    'indice_avaliacao_gravidade',
+      case
+        when rm.total_acidentes_afastamento > 0
+          then round(((rm.dias_perdidos + rm.dias_debitados) / rm.total_acidentes_afastamento), 2)
+        else 0
+      end,
+    'total_trabalhadores', coalesce(pt.total_trabalhadores, 0),
+    'indice_relativo_acidentes',
+      case
+        when coalesce(pt.total_trabalhadores, 0) > 0
+          then round((rm.total_acidentes_afastamento::numeric * 1000) / pt.total_trabalhadores, 2)
+        else 0
+      end
+  ) as resumo,
+  coalesce(t.tendencia, '[]'::jsonb) as tendencia,
+  coalesce(tp.tipos, '[]'::jsonb) as tipos,
+  coalesce(pa.partes_lesionadas, '[]'::jsonb) as partes_lesionadas,
+  coalesce(ls.lesoes, '[]'::jsonb) as lesoes,
+  coalesce(cg.cargos, '[]'::jsonb) as cargos,
+  coalesce(ag.agentes, '[]'::jsonb) as agentes,
+  coalesce(pc.pessoas_por_centro, '[]'::jsonb) as pessoas_por_centro
+from resumo_metricas rm
+left join pessoas_totais pt on pt.account_owner_id = rm.account_owner_id
+left join tendencia t on t.account_owner_id = rm.account_owner_id and t.ano = rm.ano
+left join tipos tp on tp.account_owner_id = rm.account_owner_id and tp.ano = rm.ano
+left join partes pa on pa.account_owner_id = rm.account_owner_id and pa.ano = rm.ano
+left join lesoes ls on ls.account_owner_id = rm.account_owner_id and ls.ano = rm.ano
+left join cargos cg on cg.account_owner_id = rm.account_owner_id and cg.ano = rm.ano
+left join agentes ag on ag.account_owner_id = rm.account_owner_id and ag.ano = rm.ano
+left join pessoas_centro pc on pc.account_owner_id = rm.account_owner_id and pc.ano = rm.ano
+order by rm.ano desc;
+
+grant select on public.vw_indicadores_acidentes to authenticated, service_role;


### PR DESCRIPTION
- O que foi feito:
  - Corrige o fallback JS para somar HHT mensal ativo por periodo/centro.
  - Inclui centro_servico_id na consulta de HHT do dashboard.
  - Cria migration para recriar vw_indicadores_acidentes com HHT agregado por periodo e account_owner_id.
  - Atualiza docs e TASKS com diagnostico e validacao.

- Arquivos:
  - src/lib/acidentesDashboard.js
  - src/services/api.js
  - supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql
  - docs/DashboardAcidentes.txt
  - TASKS.md

- Como validar:
  - npm run build
  - npx eslint src/lib/acidentesDashboard.js
  - Abrir Dashboard de Acidentes em 2026 e conferir HHT Total.

- Multi-tenant:
  - View nova usa account_owner_id e security_invoker para respeitar RLS.

- Docs:
  - docs/DashboardAcidentes.txt atualizado