### PR TITLE
fix(estoque): corrigir carga inicial e busca por CA

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -45,6 +45,7 @@
 - Corrigido o fallback JS do Dashboard de Acidentes para somar HHT mensal ativo por periodo/centro, independente de acidente no mesmo centro/mes.
 - Migration `supabase/migrations/20260801_fix_dashboard_acidentes_hht_total.sql` criada para recriar `vw_indicadores_acidentes` com HHT mensal agregado por periodo e `account_owner_id`.
 - Documentacao `docs/DashboardAcidentes.txt` atualizada com o diagnostico do HHT 2026 e o comportamento antes/depois.
+- Tela `Estoque atual` corrigida para buscar por CA/termo sem zerar movimentacoes, sem aplicar `ilike` em colunas UUID de centro e carregar a visao padrao ao abrir a tela.
 
 ## Pendente
 - Confirmar dominios de producao/staging para configurar whitelist CORS via `CORS_ALLOWED_ORIGINS`.
@@ -99,3 +100,4 @@
 - Auth 2026-05-09: admins recebiam email de recuperacao porque eram resolvidos em `app_users`; dependentes podiam receber sucesso sem envio quando estavam apenas em `app_users_dependentes`, pois `auth-recover` nao tinha o fallback existente no login.
 - Auth 2026-05-09: se o request log mostrar 500 em `auth-recover`, verificar Function Logs da mesma execucao; o log agora informa `stage` para separar falha de rate limit, lookup do dependente/owner ou envio pelo Supabase Auth.
 - Dashboard Acidentes 2026-08-01: para o owner `59191387-669b-4585-8e11-7070d9769d86`, havia 5 HHT ativos em 03/2026 somando 99.120,67 e 24 acidentes ativos em 2026; nenhum grupo `mes + centro_servico_id` dos acidentes tinha HHT correspondente, por isso a regra antiga retornava HHT total 0.
+- Estoque 2026-08-01: `npm run build` passou apos a correcao do filtro; `npm run lint` continua bloqueado por pendencias gerais preexistentes no projeto. A tela voltou a aplicar filtros somente pelo botao "Aplicar filtros" e a carga inicial deixou de depender da trava global `hasRunInitialLoad`.

--- a/docs/Estoque.txt
+++ b/docs/Estoque.txt
@@ -28,7 +28,7 @@ Filtros
 - Periodo inicial/final (mes/ano) so e aplicado quando "Movimentacao do periodo" esta ativo.
 - Com "Movimentacao do periodo" desligado, o estoque mostra o saldo fisico acumulado (posicao atual).
 - Com "Movimentacao do periodo" ativo, a lista mostra apenas materiais com movimentacao no intervalo (saldo pode ficar negativo).
-- Termo de busca (nome do material, fabricante, centro).
+- Termo de busca (nome do material, fabricante, CA, ID, grupo, cor e caracteristicas).
 - Centro de estoque/servico.
 - Quantidade (>= valor) para filtrar por saldo minimo exibido.
 - Checkboxes:
@@ -94,6 +94,31 @@ Boas praticas
 Melhoria possivel
 -----------------
 - Criar um RPC no Supabase para calcular o saldo do Estoque atual (com corte por data inicio/fim), reduzindo trafego e CPU no frontend; deve respeitar account_owner_id/RLS.
+
+Atualizacao 2026-08
+-------------------
+- Arquivos alterados:
+  - src/services/api.js
+  - docs/Estoque.txt
+  - TASKS.md
+- Funcoes/hooks tocadas:
+  - useEstoque
+  - useEstoqueFiltro.handleChange
+  - EstoqueContext.handleFilterChange
+  - api.estoque.current
+  - carregarSaidas
+  - buscarCatalogoIdsPorTermo
+  - buscarCentrosEstoqueIdsPorTermo
+  - buscarCentrosCustoIdsPorTermo
+  - buscarCentrosServicoIdsPorTermo
+- Comportamento antes/depois:
+  - Antes: a tela enviava `termo` e `centroCusto` para as consultas brutas de entradas/saidas; buscar por CA podia remover as movimentacoes antes do filtro local e fazer o material sumir.
+  - Antes: filtros textuais de centro em saidas podiam usar `ilike` em colunas UUID (`centro_custo`, `centro_servico`, `centro_estoque`), gerando erro `operator does not exist: uuid ~~* unknown`.
+  - Antes: a carga inicial podia ser pulada ao reabrir a tela porque havia uma trava global (`hasRunInitialLoad`) fora do hook.
+  - Depois: `api.estoque.current` consulta movimentacoes apenas por periodo/data/materialId e aplica busca/centro/quantidade/alertas no filtro local da tela.
+  - Depois: filtros textuais de centro em saidas tentam resolver IDs pelo catalogo antes da query e usam fallback local por nome, sem `ilike` em UUID.
+  - Depois: a tela sempre executa a carga inicial ao montar, sem depender de estado global entre aberturas.
+  - Depois: filtros continuam sendo aplicados somente ao clicar em "Aplicar filtros"; editar campos apenas prepara o rascunho do filtro.
 
 Atualizacao 2026-01
 -------------------

--- a/src/context/EstoqueContext.jsx
+++ b/src/context/EstoqueContext.jsx
@@ -50,13 +50,7 @@ export function EstoqueProvider({ children }) {
   }
 
   const handleFilterChange = (event) => {
-    const { name, value, type, checked } = event.target
-    const nextValue = type === 'checkbox' ? checked : value
-    const nextFilters = { ...filtroState.filters, [name]: nextValue }
     filtroState.handleChange(event)
-    if (name === 'movimentacaoPeriodo') {
-      applyFilters(nextFilters)
-    }
   }
 
   const value = {

--- a/src/hooks/useEstoque.js
+++ b/src/hooks/useEstoque.js
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { listEstoqueAtual } from '../services/estoqueApi.js'
 import { updateMaterial } from '../services/materiaisService.js'
 
-let hasRunInitialLoad = false
-
 export function useEstoque(initialFilters, userResolver, onError) {
   const [estoque, setEstoque] = useState({ itens: [], alertas: [] })
   const [estoqueBase, setEstoqueBase] = useState({ itens: [], alertas: [] })
@@ -94,11 +92,10 @@ export function useEstoque(initialFilters, userResolver, onError) {
   )
 
   useEffect(() => {
-    if (initRef.current || hasRunInitialLoad) {
+    if (initRef.current) {
       return
     }
     initRef.current = true
-    hasRunInitialLoad = true
     load({ ...initialFilters }, { force: true })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/hooks/useEstoqueFiltro.js
+++ b/src/hooks/useEstoqueFiltro.js
@@ -135,9 +135,6 @@ export function useEstoqueFiltro(initialFilters, estoque, estoqueBase = null) {
     const { name, value, type, checked } = event.target
     const nextValue = type === 'checkbox' ? checked : value
     setFilters((prev) => ({ ...prev, [name]: nextValue }))
-    if (type === 'checkbox') {
-      setAppliedFilters((prev) => ({ ...prev, [name]: nextValue }))
-    }
   }
 
   useEffect(() => {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3347,17 +3347,17 @@ async function carregarCentrosCusto() {
   })
 }
 
-async function buscarCentrosEstoqueIdsPorTermo(valor) {
+async function buscarCatalogoIdsPorTermo({ table, nameColumn, errorMessage }, valor) {
   const termo = trim(valor)
   if (!termo) {
     return []
   }
   try {
     const registros = await loadCatalogList({
-      table: 'centros_estoque',
-      nameColumn: 'almox',
+      table,
+      nameColumn,
       ownerScoped: true,
-      errorMessage: 'Falha ao consultar centros de estoque.',
+      errorMessage,
     })
     const like = normalizeSearchTerm(termo)
     return (registros ?? [])
@@ -3365,9 +3365,42 @@ async function buscarCentrosEstoqueIdsPorTermo(valor) {
       .map((item) => item?.id)
       .filter(Boolean)
   } catch (error) {
-    reportClientError('Falha ao filtrar centros de estoque por nome.', error, { termo })
+    reportClientError(`Falha ao filtrar ${table} por nome.`, error, { termo })
     return []
   }
+}
+
+async function buscarCentrosEstoqueIdsPorTermo(valor) {
+  return buscarCatalogoIdsPorTermo(
+    {
+      table: 'centros_estoque',
+      nameColumn: 'almox',
+      errorMessage: 'Falha ao consultar centros de estoque.',
+    },
+    valor
+  )
+}
+
+async function buscarCentrosCustoIdsPorTermo(valor) {
+  return buscarCatalogoIdsPorTermo(
+    {
+      table: 'centros_custo',
+      nameColumn: 'nome',
+      errorMessage: 'Falha ao consultar centros de custo.',
+    },
+    valor
+  )
+}
+
+async function buscarCentrosServicoIdsPorTermo(valor) {
+  return buscarCatalogoIdsPorTermo(
+    {
+      table: 'centros_servico',
+      nameColumn: 'nome',
+      errorMessage: 'Falha ao consultar centros de servico.',
+    },
+    valor
+  )
 }
 
 async function carregarCentrosEstoqueCatalogo() {
@@ -3946,26 +3979,48 @@ async function carregarSaidas(params = {}) {
   }
 
   const centroEstoqueFiltro = trim(params.centroEstoque || params.centro_estoque)
+  let centroEstoqueFiltroTerm = ''
   if (centroEstoqueFiltro) {
     if (isUuidValue(centroEstoqueFiltro)) {
       query = query.eq('centro_estoque', centroEstoqueFiltro)
     } else {
-      query = query.ilike('centro_estoque', `%${centroEstoqueFiltro}%`)
+      const centroIds = await buscarCentrosEstoqueIdsPorTermo(centroEstoqueFiltro)
+      if (centroIds.length) {
+        query = query.in('centro_estoque', centroIds)
+      } else {
+        centroEstoqueFiltroTerm = normalizeSearchTerm(centroEstoqueFiltro)
+      }
     }
   }
 
   const centroCustoFiltro = trim(params.centroCusto)
+  let centroCustoFiltroTerm = ''
   if (centroCustoFiltro) {
-    query = isUuidValue(centroCustoFiltro)
-      ? query.eq('centro_custo', centroCustoFiltro)
-      : query.ilike('centro_custo', `%${centroCustoFiltro}%`)
+    if (isUuidValue(centroCustoFiltro)) {
+      query = query.eq('centro_custo', centroCustoFiltro)
+    } else {
+      const centroIds = await buscarCentrosCustoIdsPorTermo(centroCustoFiltro)
+      if (centroIds.length) {
+        query = query.in('centro_custo', centroIds)
+      } else {
+        centroCustoFiltroTerm = normalizeSearchTerm(centroCustoFiltro)
+      }
+    }
   }
 
   const centroServicoFiltro = trim(params.centroServico)
+  let centroServicoFiltroTerm = ''
   if (centroServicoFiltro) {
-    query = isUuidValue(centroServicoFiltro)
-      ? query.eq('centro_servico', centroServicoFiltro)
-      : query.ilike('centro_servico', `%${centroServicoFiltro}%`)
+    if (isUuidValue(centroServicoFiltro)) {
+      query = query.eq('centro_servico', centroServicoFiltro)
+    } else {
+      const centroIds = await buscarCentrosServicoIdsPorTermo(centroServicoFiltro)
+      if (centroIds.length) {
+        query = query.in('centro_servico', centroIds)
+      } else {
+        centroServicoFiltroTerm = normalizeSearchTerm(centroServicoFiltro)
+      }
+    }
   }
 
   const dataInicioIso = toStartOfDayUtcIso(params.dataInicio)
@@ -3985,6 +4040,22 @@ async function carregarSaidas(params = {}) {
   registros = await preencherStatusSaida(registros)
   registros = await preencherCentrosCustoSaidas(registros)
   registros = await preencherCentrosServicoSaidas(registros)
+
+  if (centroEstoqueFiltroTerm) {
+    registros = registros.filter((saida) =>
+      normalizeSearchTerm(saida?.centroEstoque).includes(centroEstoqueFiltroTerm)
+    )
+  }
+  if (centroCustoFiltroTerm) {
+    registros = registros.filter((saida) =>
+      normalizeSearchTerm(saida?.centroCusto).includes(centroCustoFiltroTerm)
+    )
+  }
+  if (centroServicoFiltroTerm) {
+    registros = registros.filter((saida) =>
+      normalizeSearchTerm(saida?.centroServico).includes(centroServicoFiltroTerm)
+    )
+  }
 
   const termo = trim(params.termo).toLowerCase()
   if (termo) {
@@ -6212,22 +6283,26 @@ export const api = {
         params?.movimentacaoPeriodo === true ||
         params?.movimentacaoPeriodo === 'true' ||
         params?.modo === 'periodo'
-      const limparPeriodo = (rawParams) => {
-        const { periodoInicio, periodoFim, ano, mes, dataInicio, dataFim, movimentacaoPeriodo, modo, ...rest } =
-          rawParams || {}
-        return rest
-      }
       const periodoRange = usarMovimentacao ? resolvePeriodoRange(periodo) : null
       const hasExplicitDate = Boolean(params.dataInicio || params.dataFim)
-      const queryParams = usarMovimentacao
-        ? !hasExplicitDate && periodoRange?.start && periodoRange?.end
-          ? {
-              ...params,
-              dataInicio: periodoRange.start.toISOString(),
-              dataFim: periodoRange.end.toISOString(),
-            }
-          : params
-        : limparPeriodo(params)
+      const queryParams = {}
+      if (params?.materialId) {
+        queryParams.materialId = params.materialId
+      }
+      if (usarMovimentacao) {
+        if (hasExplicitDate) {
+          if (params.dataInicio) queryParams.dataInicio = params.dataInicio
+          if (params.dataFim) queryParams.dataFim = params.dataFim
+        } else if (periodoRange?.start && periodoRange?.end) {
+          queryParams.dataInicio = periodoRange.start.toISOString()
+          queryParams.dataFim = periodoRange.end.toISOString()
+        } else {
+          if (params.periodoInicio) queryParams.periodoInicio = params.periodoInicio
+          if (params.periodoFim) queryParams.periodoFim = params.periodoFim
+          if (params.ano) queryParams.ano = params.ano
+          if (params.mes) queryParams.mes = params.mes
+        }
+      }
       const [materiais, entradas, saidas] = await Promise.all([
         carregarMateriais(),
         carregarEntradas(queryParams),


### PR DESCRIPTION
- O que foi feito:
  - Removida trava global que impedia a carga inicial ao reabrir Estoque atual.
  - Mantido filtro por clique no botao Aplicar filtros.
  - Corrigida busca por CA/termo sem zerar movimentacoes.
  - Corrigido uso indevido de ilike em colunas UUID de centro.

- Arquivos:
  - src/services/api.js
  - src/hooks/useEstoque.js
  - src/hooks/useEstoqueFiltro.js
  - src/context/EstoqueContext.jsx
  - docs/Estoque.txt
  - TASKS.md

- Como validar:
  - npm run build
  - Abrir Estoque atual
  - Confirmar que a lista padrão carrega sem clicar em Aplicar filtros
  - Digitar CA 51495 e clicar Aplicar filtros
  - Confirmar que o resultado aparece sem erro uuid ~~*

- Multi-tenant:
  - Sem alteracao de schema/RLS.
  - Mantido uso do client autenticado e catalogos owner-scoped.

- Docs:
  - docs/Estoque.txt atualizado
  - TASKS.md atualizado