### PR TITLE
fix(analise-estoque): corrige informativo do estoque utilizavel no or…

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -72,6 +72,9 @@
 - Migration incremental `20260801_purchase_budget_validation_audit.sql` foi criada para corrigir a anualizacao de demanda intermitente no orcamento e expor `validacao_orcamento`.
 - Aba `Auditoria` da Analise de Estoque passou a abrir a validacao do orcamento em modal, com resumo financeiro, filtros de qualidade e tabela por material com forecast bruto, travado, fator de crescimento, precos e impacto.
 - Modal de validacao do orcamento passou a permitir copiar a tabela filtrada e exportar a mesma visao em CSV.
+- Aba `Previsao de Orcamento` passou a explicar no card principal e na composicao que o estoque utilizavel reduz novas compras, sem representar caixa disponivel.
+- Aba `Previsao de Orcamento` passou a comparar compras realizadas na base historica com a verba recomendada do cenario-base.
+- Explicacao do `Estoque utilizavel considerado` na composicao do orcamento passou a usar icone informativo com tooltip no padrao do forecast, com ajuste para evitar corte visual.
 
 ## Pendente
 - Aplicar a migration `supabase/migrations/20260801_purchase_budget_12m.sql` no projeto Supabase para ativar o orcamento anual da aba Previsao de Orcamento.

--- a/docs/AnaliseEstoque.txt
+++ b/docs/AnaliseEstoque.txt
@@ -277,6 +277,9 @@ Atualizacao 2026-08 (orcamento anual de compra)
 - O front normaliza `owner_id` e `forecast_id` antes de chamar as RPCs; `forecast_id` vazio/invalido vira `null`, permitindo que o banco use o snapshot mais recente sem erro 22P02.
 - A tela passou a carregar o orcamento anual em paralelo com auditoria e reposicao atual.
 - A tela passou a exibir a aba `Previsao de Orcamento` com bloco `Orcamento de compras - proximos 12 meses`, cenario-base recomendado, cenarios comparativos, composicao do orcamento, cronograma financeiro e modal de componentes da verba.
+- O card `Verba recomendada - cenario-base` passou a explicar que o estoque utilizavel existente reduz a necessidade de novas compras.
+- A aba passou a mostrar comparacao entre compras realizadas na base historica e verba recomendada, destacando a reducao/aumento previsto.
+- A linha `Estoque utilizavel considerado` da composicao passou a exibir icone informativo com tooltip no padrao do forecast, informando que o valor reduz novas compras, mas nao significa saldo financeiro disponivel.
 - A composicao do orcamento passou a mostrar `Ajuste por necessidade individual`, porque o calculo aplica necessidade material a material e o excesso de um item nao compensa a falta de outro.
 - O antigo bloco `Materiais que mais impactam` saiu da tela principal e passou para o modal `Maiores componentes da verba projetada`, aberto pelo botao `Lista consolidada de materiais`.
 - O modal de componentes da verba tem visoes separadas para maiores valores do orcamento, maiores riscos de falta e maiores oportunidades de reducao.

--- a/src/help/helpAnaliseEstoque.json
+++ b/src/help/helpAnaliseEstoque.json
@@ -36,6 +36,8 @@
       "A aba Compra prioriza a recomendacao do RPC de compra, calculada por estoque atual, estoque minimo, consumo recente e cobertura.",
       "A aba Previsao de Orcamento mostra o Orcamento de compras - proximos 12 meses, calculado separadamente da reposicao atual.",
       "A Previsao de Orcamento mostra a verba recomendada do cenario-base, cenarios comparativos, composicao reconciliada e cronograma financeiro.",
+      "Na Previsao de Orcamento, o estoque utilizavel reduz a necessidade de novas compras; esse valor nao representa dinheiro em caixa.",
+      "A comparacao com os 12 meses anteriores mostra compras realizadas, verba recomendada e reducao ou aumento previsto.",
       "Na composicao do orcamento, use Lista consolidada de materiais para abrir o modal Maiores componentes da verba projetada.",
       "O modal de orcamento responde: o que mais exigira dinheiro no proximo periodo? Ele compara gasto historico 12m, quantidade prevista, estoque utilizavel, quantidade a comprar, preco futuro e impacto no orcamento.",
       "A quantidade geral da Compra e exibida por materiais recomendados, sem somar unidades, pares, metros ou litros em um unico total.",

--- a/src/pages/AnaliseEstoquePage.jsx
+++ b/src/pages/AnaliseEstoquePage.jsx
@@ -2023,6 +2023,12 @@ export function AnaliseEstoquePage() {
     const pedidosEmAberto = Number(composicao.pedidos_em_aberto || 0)
     const reajustePrecos = Number(composicao.reajuste_precos || 0)
     const contingencia = Number(composicao.contingencia || 0)
+    const comprasHistoricasValor = (historicoSerieFull.length ? historicoSerieFull : historicoSerie).reduce(
+      (acc, item) => acc + Number(item.valor_entrada || 0),
+      0,
+    )
+    const reducaoHistoricaValor = comprasHistoricasValor - verbaRecomendada
+    const reducaoHistoricaPercentual = comprasHistoricasValor > 0 ? (reducaoHistoricaValor / comprasHistoricasValor) * 100 : null
     const necessidadeGlobal = consumoPrevisto + estoqueFinalDesejado + demandaExtraordinaria - estoqueUtilizavel - pedidosEmAberto
     const ajusteIndividual = necessidadeLiquida - necessidadeGlobal
     const composicaoRows = [
@@ -2046,9 +2052,12 @@ export function AnaliseEstoquePage() {
       },
       {
         id: 'estoque-utilizavel',
-        label: 'Estoque utilizavel',
+        label: 'Estoque utilizavel considerado',
         value: estoqueUtilizavel,
         effect: 'subtract',
+        effectLabel: 'Reduz novas compras',
+        note:
+          'Valor do estoque existente que pode ser usado para atender a demanda prevista. Esse estoque reduz a necessidade de novas compras, mas nao significa saldo financeiro disponivel.',
       },
       {
         id: 'pedidos-abertos',
@@ -2114,6 +2123,10 @@ export function AnaliseEstoquePage() {
       necessidadeLiquida,
       valorComReajuste,
       contingenciaValor: Number(resumo.contingencia_valor || 0),
+      estoqueUtilizavel,
+      comprasHistoricasValor,
+      reducaoHistoricaValor,
+      reducaoHistoricaPercentual,
       materiaisMonitorados: Number(resumo.materiais_monitorados || 0),
       materiaisOrcados: Number(resumo.materiais_orcados || 0),
       materiaisRisco: Number(resumo.materiais_risco || 0),
@@ -2129,7 +2142,7 @@ export function AnaliseEstoquePage() {
       validacaoMateriais,
       parametros,
     }
-  }, [forecastOrcamentoPayload, materialInfoMap])
+  }, [forecastOrcamentoPayload, historicoSerie, historicoSerieFull, materialInfoMap])
 
   const compraDetailItems = compraDetailModal?.items || []
   const compraDetailStart = (compraDetailPage - 1) * forecastPageSize
@@ -2829,6 +2842,12 @@ export function AnaliseEstoquePage() {
                 </header>
                 <strong className="dashboard-insight-card__value">{formatCurrency(compraOrcamentoInsights.verbaRecomendada)}</strong>
                 <span className="dashboard-insight-card__helper">Valor estimado para atender o consumo projetado, manter cobertura e considerar reajuste e contingencia.</span>
+                <div className="analysis-budget-stock-note">
+                  <InfoIcon size={16} aria-hidden="true" />
+                  <span>
+                    A verba recomendada considera o estoque ja disponivel. Como {formatCurrency(compraOrcamentoInsights.estoqueUtilizavel)} do estoque atual pode atender parte da demanda futura, a necessidade de novas compras fica menor.
+                  </span>
+                </div>
               </article>
               {compraOrcamentoInsights.cenarioEconomico ? (
                 <article className="dashboard-insight-card dashboard-insight-card--green analysis-budget-scenario-card">
@@ -2859,6 +2878,35 @@ export function AnaliseEstoquePage() {
                 </article>
               ) : null}
             </div>
+            {compraOrcamentoInsights.comprasHistoricasValor > 0 ? (
+              <div className="analysis-budget-comparison">
+                <div>
+                  <p className="analysis-forecast-label">Comparacao com os 12 meses anteriores</p>
+                  <p className="analysis-forecast-subtitle">
+                    Motivo principal: uso do estoque acumulado para atender parte da demanda futura.
+                  </p>
+                </div>
+                <dl className="analysis-budget-comparison__metrics">
+                  <div>
+                    <dt>Compras realizadas</dt>
+                    <dd>{formatCurrency(compraOrcamentoInsights.comprasHistoricasValor)}</dd>
+                  </div>
+                  <div>
+                    <dt>Verba recomendada</dt>
+                    <dd>{formatCurrency(compraOrcamentoInsights.verbaRecomendada)}</dd>
+                  </div>
+                  <div>
+                    <dt>{compraOrcamentoInsights.reducaoHistoricaValor >= 0 ? 'Reducao prevista' : 'Aumento previsto'}</dt>
+                    <dd>
+                      {formatCurrency(Math.abs(compraOrcamentoInsights.reducaoHistoricaValor))}
+                      {compraOrcamentoInsights.reducaoHistoricaPercentual !== null
+                        ? ` (${formatPercent(Math.abs(compraOrcamentoInsights.reducaoHistoricaPercentual), 1)})`
+                        : ''}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            ) : null}
             <div className="analysis-forecast-grid analysis-forecast-grid--equal">
               <article className="analysis-forecast-card analysis-forecast-card--list">
                 <div className="analysis-forecast-card__heading">
@@ -2878,7 +2926,7 @@ export function AnaliseEstoquePage() {
                     <span>Lista consolidada de materiais</span>
                   </button>
                 </div>
-                <div className="table-wrapper">
+                <div className="table-wrapper analysis-budget-composition-table">
                   <table className="data-table analysis-audit-table">
                     <thead>
                       <tr>
@@ -2890,9 +2938,23 @@ export function AnaliseEstoquePage() {
                     <tbody>
                       {compraOrcamentoInsights.composicaoRows.map((row) => (
                         <tr key={row.id}>
-                          <td>{row.label}</td>
                           <td>
-                            {row.effect === 'subtract' ? 'reduz' : row.effect === 'total' ? 'resultado' : row.effect === 'subtotal' ? 'subtotal' : 'soma'}
+                            <span className="analysis-budget-component-label">
+                              {row.label}
+                              {row.note ? (
+                                <button
+                                  type="button"
+                                  className="summary-tooltip analysis-budget-component-tooltip"
+                                  aria-label={`Informacao sobre ${row.label}`}
+                                  data-tooltip={row.note}
+                                >
+                                  <InfoIcon size={13} aria-hidden="true" />
+                                </button>
+                              ) : null}
+                            </span>
+                          </td>
+                          <td>
+                            {row.effectLabel || (row.effect === 'subtract' ? 'reduz' : row.effect === 'total' ? 'resultado' : row.effect === 'subtotal' ? 'subtotal' : 'soma')}
                           </td>
                           <td className={row.effect === 'subtract' ? 'analysis-budget-value--subtract' : undefined}>
                             {row.effect === 'subtract'

--- a/src/styles/DashboardPage.css
+++ b/src/styles/DashboardPage.css
@@ -834,6 +834,135 @@
   font-weight: 600;
 }
 
+.analysis-budget-stock-note {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  margin-top: 0.9rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(14, 165, 233, 0.18);
+  background: rgba(240, 249, 255, 0.78);
+  color: #0f4f6f;
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.analysis-budget-stock-note svg {
+  flex: 0 0 auto;
+  margin-top: 0.1rem;
+}
+
+.analysis-budget-comparison {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 1.4fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.15rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 252, 0.96);
+}
+
+.analysis-budget-comparison__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.analysis-budget-comparison__metrics div {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.7rem;
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.analysis-budget-comparison__metrics dt {
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.analysis-budget-comparison__metrics dd {
+  margin: 0.25rem 0 0;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.analysis-budget-component-label {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.analysis-budget-composition-table {
+  overflow: visible;
+  padding-top: 0.3rem;
+}
+
+.analysis-budget-composition-table .data-table {
+  min-width: 0;
+}
+
+.analysis-budget-composition-table td {
+  overflow: visible;
+}
+
+.analysis-budget-component-tooltip {
+  width: 1.25rem;
+  height: 1.25rem;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.analysis-budget-component-tooltip::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 0.55rem);
+  top: 50%;
+  width: 260px;
+  max-width: min(260px, 70vw);
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.45rem;
+  background: #0f172a;
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translateY(-50%);
+  transition: opacity 0.2s ease;
+  white-space: normal;
+  z-index: 80;
+}
+
+.analysis-budget-component-tooltip::after {
+  content: "";
+  position: absolute;
+  left: calc(100% + 0.2rem);
+  top: 50%;
+  width: 0;
+  height: 0;
+  border: 0.35rem solid transparent;
+  border-right-color: #0f172a;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity 0.2s ease;
+  z-index: 81;
+}
+
+.analysis-budget-component-tooltip:hover::before,
+.analysis-budget-component-tooltip:focus-visible::before,
+.analysis-budget-component-tooltip:hover::after,
+.analysis-budget-component-tooltip:focus-visible::after {
+  opacity: 1;
+}
+
 .analysis-budget-validation-summary {
   margin-top: 0.9rem;
 }
@@ -1028,6 +1157,12 @@
     align-items: stretch;
   }
   .analysis-budget-scenarios {
+    grid-template-columns: 1fr;
+  }
+  .analysis-budget-comparison {
+    grid-template-columns: 1fr;
+  }
+  .analysis-budget-comparison__metrics {
     grid-template-columns: 1fr;
   }
   .analysis-forecast-card__heading,


### PR DESCRIPTION
…camento

O que foi feito:
- Adiciona explicacao no card Verba recomendada - cenario-base sobre o impacto do estoque utilizavel.
- Adiciona comparacao com os 12 meses anteriores, mostrando compras realizadas, verba recomendada e reducao/aumento previsto.
- Renomeia a linha da composicao para Estoque utilizavel considerado.
- Corrige o tooltip informativo dessa linha para seguir o padrao visual do forecast.
- Troca o conteudo interno do tooltip para data-tooltip com pseudo-elementos CSS, evitando texto solto fora do balao escuro.
- Ajusta o wrapper da tabela de composicao para evitar corte visual do tooltip.
- Atualiza ajuda contextual, documentacao da tela e TASKS.md.

Arquivos tocados:
- src/pages/AnaliseEstoquePage.jsx
- src/styles/DashboardPage.css
- src/help/helpAnaliseEstoque.json
- docs/AnaliseEstoque.txt
- TASKS.md

Mapeamento por modulo/tela:
- Analise de Estoque / Previsao de Orcamento:
  - Card principal passa a explicar que o estoque ja disponivel reduz a necessidade de novas compras.
  - Composicao do orcamento passa a exibir Estoque utilizavel considerado com icone informativo e tooltip escuro.
  - Comparativo historico passa a mostrar a relacao entre compras realizadas e verba recomendada.
- Ajuda contextual:
  - Inclui orientacao de que estoque utilizavel reduz compra futura, mas nao representa caixa disponivel.
- Documentacao:
  - Registra o comportamento novo da aba Previsao de Orcamento e do tooltip informativo.

Como validar:
- Rodar `npm run build`.
- Rodar `npx eslint src/pages/AnaliseEstoquePage.jsx`.
- Abrir Analise de Estoque > Previsao de Orcamento.
- Passar o mouse no icone ao lado de Estoque utilizavel considerado.
- Confirmar que o texto aparece dentro do tooltip escuro, sem corte e sem texto solto.
- Conferir o card Verba recomendada e o bloco Comparacao com os 12 meses anteriores.

Impacto multi-tenant:
- Sem alteracao em banco, RPC, RLS ou escopo de tenant.
- Mudanca apenas visual/documental usando dados ja carregados da tela.

Docs atualizadas:
- docs/AnaliseEstoque.txt
- TASKS.md

Validacao executada:
- `npm run build` passou.
- `npx eslint src/pages/AnaliseEstoquePage.jsx` sem erros; permanecem 2 warnings antigos de hooks nao relacionados.