### PR TITLE
fix(analise-estoque): corrige comparativo historico do orcamento

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -73,7 +73,9 @@
 - Aba `Auditoria` da Analise de Estoque passou a abrir a validacao do orcamento em modal, com resumo financeiro, filtros de qualidade e tabela por material com forecast bruto, travado, fator de crescimento, precos e impacto.
 - Modal de validacao do orcamento passou a permitir copiar a tabela filtrada e exportar a mesma visao em CSV.
 - Aba `Previsao de Orcamento` passou a explicar no card principal e na composicao que o estoque utilizavel reduz novas compras, sem representar caixa disponivel.
-- Aba `Previsao de Orcamento` passou a comparar compras realizadas na base historica com a verba recomendada do cenario-base.
+- Aba `Previsao de Orcamento` passou a comparar entradas consideradas na base do snapshot com a verba recomendada do cenario-base.
+- Comparativo historico da aba `Previsao de Orcamento` corrigido para usar apenas a serie historica filtrada do snapshot selecionado, sem somar `historico_full`.
+- Indicador `Entradas consideradas` recebeu tooltip explicando que vem do agregado mensal usado no snapshot e pode diferir do Dashboard atual se houver dados posteriores.
 - Explicacao do `Estoque utilizavel considerado` na composicao do orcamento passou a usar icone informativo com tooltip no padrao do forecast, com ajuste para evitar corte visual.
 
 ## Pendente

--- a/docs/AnaliseEstoque.txt
+++ b/docs/AnaliseEstoque.txt
@@ -278,7 +278,9 @@ Atualizacao 2026-08 (orcamento anual de compra)
 - A tela passou a carregar o orcamento anual em paralelo com auditoria e reposicao atual.
 - A tela passou a exibir a aba `Previsao de Orcamento` com bloco `Orcamento de compras - proximos 12 meses`, cenario-base recomendado, cenarios comparativos, composicao do orcamento, cronograma financeiro e modal de componentes da verba.
 - O card `Verba recomendada - cenario-base` passou a explicar que o estoque utilizavel existente reduz a necessidade de novas compras.
-- A aba passou a mostrar comparacao entre compras realizadas na base historica e verba recomendada, destacando a reducao/aumento previsto.
+- A aba passou a mostrar comparacao entre entradas consideradas na base do snapshot e verba recomendada, destacando a reducao/aumento previsto.
+- A comparacao historica da aba `Previsao de Orcamento` passou a somar somente `historicoSerie` do snapshot selecionado, evitando inflar `Entradas consideradas` com meses fora da base.
+- O indicador `Entradas consideradas` recebeu tooltip informando que a origem e o agregado mensal usado pelo snapshot, podendo diferir do Dashboard atual caso o agregado ou o snapshot ainda nao tenham sido atualizados.
 - A linha `Estoque utilizavel considerado` da composicao passou a exibir icone informativo com tooltip no padrao do forecast, informando que o valor reduz novas compras, mas nao significa saldo financeiro disponivel.
 - A composicao do orcamento passou a mostrar `Ajuste por necessidade individual`, porque o calculo aplica necessidade material a material e o excesso de um item nao compensa a falta de outro.
 - O antigo bloco `Materiais que mais impactam` saiu da tela principal e passou para o modal `Maiores componentes da verba projetada`, aberto pelo botao `Lista consolidada de materiais`.

--- a/src/help/helpAnaliseEstoque.json
+++ b/src/help/helpAnaliseEstoque.json
@@ -37,7 +37,7 @@
       "A aba Previsao de Orcamento mostra o Orcamento de compras - proximos 12 meses, calculado separadamente da reposicao atual.",
       "A Previsao de Orcamento mostra a verba recomendada do cenario-base, cenarios comparativos, composicao reconciliada e cronograma financeiro.",
       "Na Previsao de Orcamento, o estoque utilizavel reduz a necessidade de novas compras; esse valor nao representa dinheiro em caixa.",
-      "A comparacao com os 12 meses anteriores mostra compras realizadas, verba recomendada e reducao ou aumento previsto.",
+      "A comparacao com a base do snapshot mostra entradas consideradas no agregado mensal do snapshot, verba recomendada e reducao ou aumento previsto.",
       "Na composicao do orcamento, use Lista consolidada de materiais para abrir o modal Maiores componentes da verba projetada.",
       "O modal de orcamento responde: o que mais exigira dinheiro no proximo periodo? Ele compara gasto historico 12m, quantidade prevista, estoque utilizavel, quantidade a comprar, preco futuro e impacto no orcamento.",
       "A quantidade geral da Compra e exibida por materiais recomendados, sem somar unidades, pares, metros ou litros em um unico total.",

--- a/src/pages/AnaliseEstoquePage.jsx
+++ b/src/pages/AnaliseEstoquePage.jsx
@@ -2023,12 +2023,13 @@ export function AnaliseEstoquePage() {
     const pedidosEmAberto = Number(composicao.pedidos_em_aberto || 0)
     const reajustePrecos = Number(composicao.reajuste_precos || 0)
     const contingencia = Number(composicao.contingencia || 0)
-    const comprasHistoricasValor = (historicoSerieFull.length ? historicoSerieFull : historicoSerie).reduce(
+    const entradasSnapshotValor = historicoSerie.reduce(
       (acc, item) => acc + Number(item.valor_entrada || 0),
       0,
     )
-    const reducaoHistoricaValor = comprasHistoricasValor - verbaRecomendada
-    const reducaoHistoricaPercentual = comprasHistoricasValor > 0 ? (reducaoHistoricaValor / comprasHistoricasValor) * 100 : null
+    const variacaoEntradasSnapshotValor = entradasSnapshotValor - verbaRecomendada
+    const variacaoEntradasSnapshotPercentual =
+      entradasSnapshotValor > 0 ? (variacaoEntradasSnapshotValor / entradasSnapshotValor) * 100 : null
     const necessidadeGlobal = consumoPrevisto + estoqueFinalDesejado + demandaExtraordinaria - estoqueUtilizavel - pedidosEmAberto
     const ajusteIndividual = necessidadeLiquida - necessidadeGlobal
     const composicaoRows = [
@@ -2124,9 +2125,9 @@ export function AnaliseEstoquePage() {
       valorComReajuste,
       contingenciaValor: Number(resumo.contingencia_valor || 0),
       estoqueUtilizavel,
-      comprasHistoricasValor,
-      reducaoHistoricaValor,
-      reducaoHistoricaPercentual,
+      entradasSnapshotValor,
+      variacaoEntradasSnapshotValor,
+      variacaoEntradasSnapshotPercentual,
       materiaisMonitorados: Number(resumo.materiais_monitorados || 0),
       materiaisOrcados: Number(resumo.materiais_orcados || 0),
       materiaisRisco: Number(resumo.materiais_risco || 0),
@@ -2142,7 +2143,7 @@ export function AnaliseEstoquePage() {
       validacaoMateriais,
       parametros,
     }
-  }, [forecastOrcamentoPayload, historicoSerie, historicoSerieFull, materialInfoMap])
+  }, [forecastOrcamentoPayload, historicoSerie, materialInfoMap])
 
   const compraDetailItems = compraDetailModal?.items || []
   const compraDetailStart = (compraDetailPage - 1) * forecastPageSize
@@ -2878,29 +2879,45 @@ export function AnaliseEstoquePage() {
                 </article>
               ) : null}
             </div>
-            {compraOrcamentoInsights.comprasHistoricasValor > 0 ? (
+            {compraOrcamentoInsights.entradasSnapshotValor > 0 ? (
               <div className="analysis-budget-comparison">
                 <div>
-                  <p className="analysis-forecast-label">Comparacao com os 12 meses anteriores</p>
+                  <p className="analysis-forecast-label">Comparacao com a base do snapshot</p>
                   <p className="analysis-forecast-subtitle">
-                    Motivo principal: uso do estoque acumulado para atender parte da demanda futura.
+                    A verba recomendada esta{' '}
+                    {compraOrcamentoInsights.variacaoEntradasSnapshotPercentual !== null
+                      ? formatPercent(Math.abs(compraOrcamentoInsights.variacaoEntradasSnapshotPercentual), 1)
+                      : 'em comparacao'}{' '}
+                    {compraOrcamentoInsights.variacaoEntradasSnapshotValor >= 0 ? 'abaixo' : 'acima'} das entradas consideradas na base historica, principalmente porque {formatCurrency(compraOrcamentoInsights.estoqueUtilizavel)} do estoque atual pode atender parte da demanda futura.
                   </p>
                 </div>
                 <dl className="analysis-budget-comparison__metrics">
                   <div>
-                    <dt>Compras realizadas</dt>
-                    <dd>{formatCurrency(compraOrcamentoInsights.comprasHistoricasValor)}</dd>
+                    <dt>
+                      <span className="analysis-budget-component-label">
+                        Entradas consideradas
+                        <button
+                          type="button"
+                          className="summary-tooltip analysis-budget-component-tooltip"
+                          aria-label="Informacao sobre entradas consideradas"
+                          data-tooltip="Soma das entradas registradas no agregado mensal utilizado na base historica deste snapshot. Pode diferir do Dashboard atual se o agregado ou o snapshot nao foram atualizados depois de inclusoes, edicoes ou cancelamentos."
+                        >
+                          <InfoIcon size={13} aria-hidden="true" />
+                        </button>
+                      </span>
+                    </dt>
+                    <dd>{formatCurrency(compraOrcamentoInsights.entradasSnapshotValor)}</dd>
                   </div>
                   <div>
                     <dt>Verba recomendada</dt>
                     <dd>{formatCurrency(compraOrcamentoInsights.verbaRecomendada)}</dd>
                   </div>
                   <div>
-                    <dt>{compraOrcamentoInsights.reducaoHistoricaValor >= 0 ? 'Reducao prevista' : 'Aumento previsto'}</dt>
+                    <dt>{compraOrcamentoInsights.variacaoEntradasSnapshotValor >= 0 ? 'Reducao prevista' : 'Aumento previsto'}</dt>
                     <dd>
-                      {formatCurrency(Math.abs(compraOrcamentoInsights.reducaoHistoricaValor))}
-                      {compraOrcamentoInsights.reducaoHistoricaPercentual !== null
-                        ? ` (${formatPercent(Math.abs(compraOrcamentoInsights.reducaoHistoricaPercentual), 1)})`
+                      {formatCurrency(Math.abs(compraOrcamentoInsights.variacaoEntradasSnapshotValor))}
+                      {compraOrcamentoInsights.variacaoEntradasSnapshotPercentual !== null
+                        ? ` (${formatPercent(Math.abs(compraOrcamentoInsights.variacaoEntradasSnapshotPercentual), 1)})`
                         : ''}
                     </dd>
                   </div>


### PR DESCRIPTION
O que foi feito:
- Corrige o card Compras realizadas da aba Previsao de Orcamento.
- O comparativo passa a somar apenas a serie historica filtrada do snapshot selecionado.
- Remove o uso de historico_full no calculo de compras realizadas, evitando inflar o valor com meses fora da base.
- Atualiza documentacao da tela e TASKS.md.

Arquivos tocados:
- src/pages/AnaliseEstoquePage.jsx
- docs/AnaliseEstoque.txt
- TASKS.md

Mapeamento:
- Analise de Estoque / Previsao de Orcamento:
  - Compras realizadas agora usa historicoSerie, que respeita periodo_base_inicio e periodo_base_fim.
  - Reducao/aumento previsto passa a comparar a verba recomendada contra a mesma base historica do snapshot.

Como validar:
- Rodar `npm run build`.
- Abrir Analise de Estoque > Previsao de Orcamento.
- Conferir se Compras realizadas bate com o total de entradas da mesma base historica.
- Para o snapshot ago/2025 a jul/2026, o esperado e ficar proximo de R$ 38.581,77.

Impacto multi-tenant:
- Sem mudanca em banco, RPC, RLS ou escopo de tenant.
- Correcao apenas no consumo da serie ja filtrada para o owner/snapshot atual.

Docs:
- docs/AnaliseEstoque.txt atualizado.
- TASKS.md atualizado.